### PR TITLE
Fix discovery reports query forwarding and upstream error handling

### DIFF
--- a/src/getDiscoveryReports.ts
+++ b/src/getDiscoveryReports.ts
@@ -15,7 +15,11 @@ export async function getDiscoveryReports(c: Auth0ActionContext): Promise<Respon
         methods: ["POST", "GET", "OPTIONS"]
     });
     if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        const url = getEndpoint(Endpoint.discoveryCuration, c.env);
+        let url = getEndpoint(Endpoint.discoveryCuration, c.env);
+        const reqUrl = new URL(c.req.url);
+        if (reqUrl.search) {
+            url = new URL(url.toString() + reqUrl.search);
+        }
         const resp = await fetch(url, {
             headers: buildFetchHeaders(c.req, url),
             method: "GET"
@@ -28,6 +32,7 @@ export async function getDiscoveryReports(c: Auth0ActionContext): Promise<Respon
         } else {
             logCollector.addMessage(`Failed to use secure-discovery-curation-endpoint.`);
             console.error(logCollector.toEndpointLog());
+            return c.json({ error: "Error" }, 500);
         }
     }
     logCollector.addMessage("Unauthorised to use getDiscoveryReports.");


### PR DESCRIPTION
## Summary
- Forward incoming query strings to the discovery curation upstream endpoint (aligned with patterns like `getOutgoing`).
- Return HTTP 500 when the secure discovery curation call fails, instead of falling through to an unauthorised 403.

## Note
`getPodcastByNameAndEpisodeId.ts` debug `console.log` removal was described in planning but is not in this diff (working tree matches `main` for that file). Can follow up in a separate change if still desired.

## Test plan
- [ ] Call `getDiscoveryReports` with `curate` permission and query params; confirm upstream receives the same query string.
- [ ] Simulate or trigger upstream curation failure; confirm API responds with 500 and error payload, not 403.
- [ ] Call without `curate` permission; confirm response remains 403 unauthorised.
- [ ] Regression: successful curation GET still returns upstream body with 200.

Made with [Cursor](https://cursor.com)