### PR TITLE
Add People proxy routes for People register

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts-api",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "dependencies": {
         "@cfworker/jwt": "^4.0.6",
         "@prisma/adapter-d1": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/Endpoint.ts
+++ b/src/Endpoint.ts
@@ -9,6 +9,8 @@ export enum Endpoint {
     outgoingEpisodes,
     podcast,
     subject,
+    people,
+    person,
     publishHomepage,
     terms,
     pushSubscriptions,

--- a/src/Env.ts
+++ b/src/Env.ts
@@ -13,6 +13,7 @@ export type Env = {
 	securePodcastIndexEndpoint: URL;
 	securePodcastEndpoint: URL;
 	secureSubjectEndpoint: URL;
+	securePeopleEndpoint: URL;
 	secureEpisodesOutgoingEndpoint: URL;
 	secureAdminSearchIndexerEndpoint: URL;
 	secureAdminPublishHomepageEndpoint: URL;

--- a/src/createPerson.ts
+++ b/src/createPerson.ts
@@ -1,0 +1,45 @@
+import { AddResponseHeaders } from "./AddResponseHeaders";
+import { Auth0JwtPayload } from "./Auth0JwtPayload";
+import { Auth0ActionContext } from "./Auth0ActionContext";
+import { buildFetchHeaders } from "./buildFetchHeaders";
+import { LogCollector } from "./LogCollector";
+import { getEndpoint } from "./endpoints";
+import { Endpoint } from "./Endpoint";
+
+export async function createPerson(c: Auth0ActionContext): Promise<Response> {
+    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
+    const logCollector = new LogCollector();
+    logCollector.collectRequest(c);
+    AddResponseHeaders(c, { methods: ["POST", "GET", "PUT", "OPTIONS"] });
+    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
+        const url = getEndpoint(Endpoint.person, c.env);
+        const data: any = await c.req.json();
+        const body: string = JSON.stringify(data);
+        const resp = await fetch(url, {
+            headers: buildFetchHeaders(c.req, url),
+            method: "PUT",
+            body: body
+        });
+        logCollector.add({ status: resp.status });
+        if (resp.status == 202) {
+            logCollector.addMessage(`Successfully used secure-person-endpoint.`);
+            console.log(logCollector.toEndpointLog());
+            return c.newResponse(resp.body, resp.status);
+        } else if (resp.status == 409) {
+            logCollector.addMessage(`Conflict reported on secure-person-endpoint.`);
+            console.error(logCollector.toEndpointLog());
+            return c.newResponse(resp.body, resp.status);
+        } else if (resp.status == 400) {
+            logCollector.addMessage(`Bad request on secure-person-endpoint.`);
+            console.error(logCollector.toEndpointLog());
+            return c.newResponse(resp.body, resp.status);
+        } else {
+            logCollector.addMessage(`Failed to use secure-person-endpoint.`);
+            console.error(logCollector.toEndpointLog());
+            return c.json({ error: "Error" }, 500);
+        }
+    }
+    logCollector.addMessage(`Unauthorised to use createPerson.`);
+    console.error(logCollector.toEndpointLog());
+    return c.json({ error: "Unauthorised" }, 403);
+}

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -31,6 +31,15 @@ export function getEndpoint(endpoint: Endpoint, env: Env): URL {
         case Endpoint.subject:
             url = new URL(env.secureSubjectEndpoint);
             break;
+        case Endpoint.people:
+            url = new URL(env.securePeopleEndpoint);
+            break;
+        case Endpoint.person: {
+            const peopleUrl = new URL(env.securePeopleEndpoint);
+            peopleUrl.pathname = peopleUrl.pathname.replace(/\/people\/?$/, '/person');
+            url = peopleUrl;
+            break;
+        }
         case Endpoint.publishHomepage:
             url = new URL(env.secureAdminPublishHomepageEndpoint);
             break;

--- a/src/getPeople.ts
+++ b/src/getPeople.ts
@@ -1,0 +1,118 @@
+import { stream } from "hono/streaming";
+
+import { AddResponseHeaders } from "./AddResponseHeaders";
+
+import { Auth0JwtPayload } from "./Auth0JwtPayload";
+
+import { Auth0ActionContext } from "./Auth0ActionContext";
+
+import { buildFetchHeaders } from "./buildFetchHeaders";
+
+import { getEndpoint } from "./endpoints";
+
+import { Endpoint } from "./Endpoint";
+
+import { LogCollector } from "./LogCollector";
+
+
+
+export async function getPeople(c: Auth0ActionContext): Promise<Response> {
+
+	const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
+
+	const logCollector = new LogCollector();
+
+	logCollector.collectRequest(c);
+
+	if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
+
+		let object: R2ObjectBody | null = null;
+
+		try {
+
+			object = await c.env.Content.get("people");
+
+		} catch {
+
+			logCollector.addMessage("Unable to retrieve people");
+
+		}
+
+		if (object !== null) {
+
+			AddResponseHeaders(c, { etag: object.httpEtag, methods: ["GET", "OPTIONS"] });
+
+			logCollector.addMessage("Successfully obtained people data.");
+
+			console.log(logCollector.toEndpointLog());
+
+			return stream(c, async (stream) => {
+
+				stream.onAbort(() => {
+
+					logCollector.addMessage('Aborted!');
+
+					console.error(logCollector.toEndpointLog());
+
+				});
+
+				await stream.pipe(object.body);
+
+			});
+
+		}
+
+
+
+		try {
+
+			const url = getEndpoint(Endpoint.people, c.env);
+
+			const resp = await fetch(url, {
+
+				headers: buildFetchHeaders(c.req, url),
+
+				method: "GET"
+
+			});
+
+			logCollector.add({ status: resp.status });
+
+			if (resp.status === 200) {
+
+				logCollector.addMessage("Successfully used secure-people-endpoint.");
+
+				console.log(logCollector.toEndpointLog());
+
+				AddResponseHeaders(c, { omitCacheControlHeader: true, methods: ["GET", "OPTIONS"] });
+
+				return c.newResponse(resp.body);
+
+			}
+
+		} catch {
+
+			logCollector.addMessage("Unable to retrieve people from secure endpoint");
+
+		}
+
+
+
+		logCollector.addMessage(logCollector.message ?? "No people object found");
+
+		console.error(logCollector.toEndpointLog());
+
+		return c.notFound();
+
+	} else {
+
+		logCollector.addMessage("Unauthorised to use getPeople.");
+
+		console.error(logCollector.toEndpointLog());
+
+		return c.json({ message: "Unauthorised" }, 401);
+
+	}
+
+}
+

--- a/src/getPersonByName.ts
+++ b/src/getPersonByName.ts
@@ -1,0 +1,43 @@
+import { AddResponseHeaders } from "./AddResponseHeaders";
+import { Auth0JwtPayload } from "./Auth0JwtPayload";
+import { Auth0ActionContext } from "./Auth0ActionContext";
+import { buildFetchHeaders } from "./buildFetchHeaders";
+import { LogCollector } from "./LogCollector";
+import { getEndpoint } from "./endpoints";
+import { Endpoint } from "./Endpoint";
+import { encodeUrlParameter } from "./encodeUrlParameter";
+
+export async function getPersonByName(c: Auth0ActionContext): Promise<Response> {
+    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
+    const logCollector = new LogCollector();
+    logCollector.collectRequest(c);
+    const name = c.req.param('name');
+    AddResponseHeaders(c, {
+        omitCacheControlHeader: true,
+        methods: ["POST", "GET", "OPTIONS"]
+    });
+    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
+        const url = new URL(`${getEndpoint(Endpoint.person, c.env)}/${encodeUrlParameter(name)}`);
+        const resp = await fetch(url, {
+            headers: buildFetchHeaders(c.req, url),
+            method: "GET"
+        });
+        logCollector.add({ status: resp.status });
+        if (resp.status == 200) {
+            logCollector.addMessage(`Successfully used secure-person-endpoint.`);
+            console.log(logCollector.toEndpointLog());
+            return c.newResponse(resp.body);
+        } else if (resp.status == 404) {
+            logCollector.addMessage(`Person not found on secure-person-endpoint.`);
+            console.error(logCollector.toEndpointLog());
+            return c.json({ error: "Not found" }, 404);
+        } else {
+            logCollector.addMessage(`Failed to use secure-person-endpoint.`);
+            console.error(logCollector.toEndpointLog());
+            return c.json({ error: "Error" }, 500);
+        }
+    }
+    logCollector.addMessage("Unauthorised to use getPersonByName.");
+    console.log(logCollector.toEndpointLog());
+    return c.json({ error: "Unauthorised" }, 403);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { ProfileDurableObject } from './ProfileDurableObject';
 import { buildDocsPageHtml } from './resources/docsPageHtml';
 import {
 	AddBookmarkRoute,
+	CreatePersonRoute,
 	CreateSubjectRoute,
 	DeleteBookmarkRoute,
 	DeleteEpisodeRoute,
@@ -22,9 +23,11 @@ import {
 	GetLanguagesRoute,
 	GetOutgoingRoute,
 	GetPageDetailsRoute,
+	GetPersonByNameRoute,
 	GetPodcastByNameAndEpisodeIdRoute,
 	GetPodcastByNameRoute,
 	GetPodcastEpisodeRoute,
+	GetPeopleRoute,
 	GetSubjectByNameRoute,
 	GetSubjectsRoute,
 	HomepageRoute,
@@ -41,6 +44,7 @@ import {
 	SubmitDiscoveryRoute,
 	SubmitRoute,
 	UpdateEpisodeRoute,
+	UpdatePersonRoute,
 	UpdatePodcastEpisodeRoute,
 	UpdatePodcastPostRoute,
 	UpdatePodcastPutRoute,
@@ -261,6 +265,10 @@ const openapi = fromHono(app, {
 openapi.get('/homepage', HomepageRoute);
 openapi.get('/homepage-ssr', HomepageSsrRoute);
 openapi.get('/subjects', GetSubjectsRoute);
+openapi.get('/people', GetPeopleRoute);
+openapi.get('/person/:name', GetPersonByNameRoute);
+openapi.post('/person/:id', UpdatePersonRoute);
+openapi.put('/person', CreatePersonRoute);
 openapi.get('/flairs', GetFlairsRoute);
 openapi.post('/search', SearchRoute);
 openapi.post('/submit', SubmitRoute);

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -2,6 +2,7 @@ import { OpenAPIRoute, OpenAPIRouteSchema, contentJson } from "chanfana";
 import { z } from "zod";
 import { Auth0Middleware } from "./Auth0Middleware";
 import { addBookmark } from "./addBookmark";
+import { createPerson } from "./createPerson";
 import { createSubject } from "./createSubject";
 import { deleteBookmark } from "./deleteBookmark";
 import { deleteEpisode, deletePodcastEpisode } from "./deleteEpisode";
@@ -13,9 +14,11 @@ import { getFlairs } from "./getFlairs";
 import { getLanguages } from "./getLanguages";
 import { getOutgoing } from "./getOutgoing";
 import { getPageDetails } from "./getPageDetails";
+import { getPersonByName } from "./getPersonByName";
 import { getPodcastByName } from "./getPodcastByName";
 import { getPodcastByNameAndEpisodeId } from "./getPodcastByNameAndEpisodeId";
 import { getSubjectByName } from "./getSubjectByName";
+import { getPeople } from "./getPeople";
 import { getSubjects } from "./getSubjects";
 import { homepage } from "./homepage";
 import { homepageSsr } from "./homepageSsr";
@@ -31,6 +34,7 @@ import { search } from "./search";
 import { submit } from "./submit";
 import { submitDiscovery } from "./submitDiscovery";
 import { updateEpisode, updatePodcastEpisode } from "./updateEpisode";
+import { updatePerson } from "./updatePerson";
 import { updatePodcast } from "./updatePodcast";
 import { updateSubject } from "./updateSubject";
 
@@ -106,6 +110,45 @@ export const GetSubjectsRoute = createOpenApiRoute(getSubjects, {
         tags: ["Subjects"],
         summary: "List subjects",
         responses: { 200: { description: "Subjects", ...contentJson(genericOkSchema) }, ...authResponses }
+    }
+});
+
+export const GetPeopleRoute = createOpenApiRoute(getPeople, {
+    auth: true,
+    schema: {
+        tags: ["People"],
+        summary: "List people",
+        responses: { 200: { description: "People", ...contentJson(genericOkSchema) }, ...authResponses }
+    }
+});
+
+export const GetPersonByNameRoute = createOpenApiRoute(getPersonByName, {
+    auth: true,
+    schema: {
+        tags: ["People"],
+        summary: "Get person by name",
+        request: { params: nameParam },
+        responses: { 200: { description: "Person", ...contentJson(genericOkSchema) }, ...authResponses }
+    }
+});
+
+export const UpdatePersonRoute = createOpenApiRoute(updatePerson, {
+    auth: true,
+    schema: {
+        tags: ["People"],
+        summary: "Update person by id",
+        request: { params: idParam, body: jsonBodySchema },
+        responses: { 202: { description: "Person updated", ...contentJson(genericOkSchema) }, ...authResponses }
+    }
+});
+
+export const CreatePersonRoute = createOpenApiRoute(createPerson, {
+    auth: true,
+    schema: {
+        tags: ["People"],
+        summary: "Create person",
+        request: { body: jsonBodySchema },
+        responses: { 202: { description: "Person created", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
 

--- a/src/updatePerson.ts
+++ b/src/updatePerson.ts
@@ -1,0 +1,42 @@
+import { AddResponseHeaders } from "./AddResponseHeaders";
+import { Auth0JwtPayload } from "./Auth0JwtPayload";
+import { Auth0ActionContext } from "./Auth0ActionContext";
+import { buildFetchHeaders } from "./buildFetchHeaders";
+import { LogCollector } from "./LogCollector";
+import { getEndpoint } from "./endpoints";
+import { Endpoint } from "./Endpoint";
+
+export async function updatePerson(c: Auth0ActionContext): Promise<Response> {
+	const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
+	const logCollector = new LogCollector();
+	logCollector.collectRequest(c);
+	const id = c.req.param('id');
+	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
+	if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
+		const url = new URL(`${getEndpoint(Endpoint.person, c.env)}/${id}`);
+		const data: any = await c.req.json();
+		const body: string = JSON.stringify(data);
+		const resp = await fetch(url, {
+			headers: buildFetchHeaders(c.req, url),
+			method: "POST",
+			body: body
+		});
+		logCollector.add({ status: resp.status });
+		if (resp.status == 202) {
+			logCollector.addMessage(`Successfully used secure-person-endpoint.`);
+			console.log(logCollector.toEndpointLog());
+			return c.newResponse(resp.body, resp.status);
+		} else if (resp.status == 404) {
+			logCollector.addMessage(`Person not found on secure-person-endpoint.`);
+			console.error(logCollector.toEndpointLog());
+			return c.json({ error: "Not found" }, 404);
+		} else {
+			logCollector.addMessage(`Failed to use secure-person-endpoint.`);
+			console.error(logCollector.toEndpointLog());
+			return c.json({ error: "Error" }, 500);
+		}
+	}
+	logCollector.addMessage("Unauthorised to use updatePerson.");
+	console.error(logCollector.toEndpointLog());
+	return c.json({ error: "Unauthorised" }, 403);
+}


### PR DESCRIPTION
## Summary
- Adds Cloudflare worker proxies for create/update/list/get-by-name Person routes.
- Wires Endpoint/Env/openapi to upstream People/Person Azure Functions endpoints.
- Companion to RedditPodcastPoster and website People register PRs (People register + Episode.Guests UI/API only; no guests enrichment).

## Companion PRs
- RedditPodcastPoster: https://github.com/cultpodcasts/RedditPodcastPoster/pull/879
- Website: https://github.com/cultpodcasts/website/pull/409

## Test plan
- [ ] `wrangler` local: GET `/people`, GET `/person/:name`, PUT `/person`, POST `/person/:id` with Auth0
- [ ] Confirm routes proxy to `securePeopleEndpoint` / person path rewrite
- [ ] OpenAPI docs list People routes
