### PR TITLE
Fix bookmarks worker serialization and episode 404s

### DIFF
--- a/src/getBookmarks.ts
+++ b/src/getBookmarks.ts
@@ -12,7 +12,7 @@ export async function getBookmarks(c: Auth0ActionContext): Promise<Response> {
         omitCacheControlHeader: true,
         methods: ["POST", "GET", "OPTIONS"]
     });
-    if (auth0Payload) {
+    if (auth0Payload?.sub) {
         let id: DurableObjectId = c.env.PROFILE_DURABLE_OBJECT.idFromName(auth0Payload.sub);
         let stub = c.env.PROFILE_DURABLE_OBJECT.get(id);
         let result = await stub.getBookmarks(auth0Payload.sub);
@@ -21,7 +21,8 @@ export async function getBookmarks(c: Auth0ActionContext): Promise<Response> {
         } else if (result == getBookmarksResponse.errorRetrievingBookmarks) {
             return c.json({ message: "Could not retrieve bookmarks" }, 500);
         }
-        return c.json(result);
+        // Copy out of any RPC stub array so JSON serializes as a real array.
+        return c.json(Array.isArray(result) ? [...result] : result);
     }
     logCollector.addMessage(`Unauthorised to use profile-object getBookmarks method.`);
     console.error(logCollector.toEndpointLog());

--- a/src/publicGetEpisode.ts
+++ b/src/publicGetEpisode.ts
@@ -25,6 +25,12 @@ export async function publicGetEpisode(c: Auth0ActionContext): Promise<Response>
             logCollector.addMessage(`Successfully used secure-public-episode-endpoint.`);
             console.log(logCollector.toEndpointLog());
             return c.newResponse(resp.body);
+        } else if (resp.status == 404) {
+            // Forward not-found so the bookmarks page can skip missing episodes
+            // instead of treating every miss as a hard 500 failure.
+            logCollector.addMessage(`Public episode not found.`);
+            console.log(logCollector.toEndpointLog());
+            return c.newResponse(resp.body, resp.status);
         } else {
             logCollector.addMessage(`Failed to use secure-public-episode-endpoint.`);
             console.error(logCollector.toEndpointLog());


### PR DESCRIPTION
## Summary
- Require Auth0 `sub` before looking up the profile Durable Object in `getBookmarks`, avoiding unauthorized DO access on incomplete tokens.
- Copy Durable Object RPC bookmark arrays before `c.json` so Cloudflare Workers serialize a real array instead of a stub.
- Forward upstream 404 from the public episode endpoint so the bookmarks page can skip missing episodes instead of treating every miss as a hard 500.

## Test plan
- [ ] Authenticated `GET /bookmarks` returns a JSON array of bookmark IDs
- [ ] Unauthenticated or token-without-sub `GET /bookmarks` returns 403
- [ ] Public episode fetch for a missing episode returns 404 (not 500)
- [ ] Bookmarks UI loads when some bookmarked episodes no longer exist

Made with [Cursor](https://cursor.com)