### PR TITLE
feat: proxy Discovery Schedule GET/PUT

### DIFF
--- a/src/Endpoint.ts
+++ b/src/Endpoint.ts
@@ -14,5 +14,6 @@ export enum Endpoint {
     publishHomepage,
     terms,
     pushSubscriptions,
-    searchIndexer
+    searchIndexer,
+    discoverySchedule
 }

--- a/src/Env.ts
+++ b/src/Env.ts
@@ -18,6 +18,7 @@ export type Env = {
 	secureAdminSearchIndexerEndpoint: URL;
 	secureAdminPublishHomepageEndpoint: URL;
 	secureAdminTermsEndpoint: URL;
+	secureDiscoveryScheduleEndpoint: URL;
 	securePushSubscriptionEndpoint: URL;
 	stagingHostSuffix: string;
 	PROFILE_DURABLE_OBJECT: DurableObjectNamespace<import("./ProfileDurableObject").ProfileDurableObject>;

--- a/src/discoverySchedule.ts
+++ b/src/discoverySchedule.ts
@@ -1,0 +1,75 @@
+import { AddResponseHeaders } from "./AddResponseHeaders";
+import { Auth0ActionContext } from "./Auth0ActionContext";
+import { Auth0JwtPayload } from "./Auth0JwtPayload";
+import { buildFetchHeaders } from "./buildFetchHeaders";
+import { getEndpoint } from "./endpoints";
+import { Endpoint } from "./Endpoint";
+import { LogCollector } from "./LogCollector";
+import { StatusCode } from "hono/utils/http-status";
+
+export async function getDiscoverySchedule(c: Auth0ActionContext): Promise<Response> {
+    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
+    const logCollector = new LogCollector();
+    logCollector.collectRequest(c);
+    AddResponseHeaders(c, { methods: ["GET", "PUT", "OPTIONS"] });
+    try {
+        if (auth0Payload?.permissions && auth0Payload.permissions.includes('admin')) {
+            const url = getEndpoint(Endpoint.discoverySchedule, c.env);
+            const resp = await fetch(url, {
+                headers: buildFetchHeaders(c.req, url),
+                method: "GET"
+            });
+            logCollector.add({ status: resp.status });
+            if (resp.status == 200) {
+                logCollector.addMessage(`Successfully used discovery-schedule GET.`);
+                console.log(logCollector.toEndpointLog());
+                return c.newResponse(resp.body);
+            }
+            logCollector.addMessage(`Failed discovery-schedule GET.`);
+            console.error(logCollector.toEndpointLog());
+            return c.newResponse(resp.body, resp.status as StatusCode);
+        }
+    } catch {
+        logCollector.addMessage("Error in getDiscoverySchedule.");
+        console.error(logCollector.toEndpointLog());
+        return c.json({ error: "An error occurred" }, 500);
+    }
+    logCollector.addMessage("Unauthorised to use getDiscoverySchedule.");
+    console.error(logCollector.toEndpointLog());
+    return c.json({ error: "Unauthorised" }, 403);
+}
+
+export async function putDiscoverySchedule(c: Auth0ActionContext): Promise<Response> {
+    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
+    const logCollector = new LogCollector();
+    logCollector.collectRequest(c);
+    AddResponseHeaders(c, { methods: ["GET", "PUT", "OPTIONS"] });
+    const data: any = await c.req.json();
+    const body: string = JSON.stringify(data);
+    try {
+        if (auth0Payload?.permissions && auth0Payload.permissions.includes('admin')) {
+            const url = getEndpoint(Endpoint.discoverySchedule, c.env);
+            const resp = await fetch(url, {
+                headers: buildFetchHeaders(c.req, url),
+                method: "PUT",
+                body
+            });
+            logCollector.add({ status: resp.status });
+            if (resp.status == 200) {
+                logCollector.addMessage(`Successfully used discovery-schedule PUT.`);
+                console.log(logCollector.toEndpointLog());
+                return c.newResponse(resp.body);
+            }
+            logCollector.addMessage(`Failed discovery-schedule PUT.`);
+            console.error(logCollector.toEndpointLog());
+            return c.newResponse(resp.body, resp.status as StatusCode);
+        }
+    } catch {
+        logCollector.addMessage("Error in putDiscoverySchedule.");
+        console.error(logCollector.toEndpointLog());
+        return c.json({ error: "An error occurred" }, 500);
+    }
+    logCollector.addMessage("Unauthorised to use putDiscoverySchedule.");
+    console.error(logCollector.toEndpointLog());
+    return c.json({ error: "Unauthorised" }, 403);
+}

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -46,6 +46,9 @@ export function getEndpoint(endpoint: Endpoint, env: Env): URL {
         case Endpoint.terms:
             url = new URL(env.secureAdminTermsEndpoint);
             break;
+        case Endpoint.discoverySchedule:
+            url = new URL(env.secureDiscoveryScheduleEndpoint);
+            break;
         case Endpoint.pushSubscriptions:
             url = new URL(env.securePushSubscriptionEndpoint);
             break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ import {
 	PublishHomepageRoute,
 	PublishPodcastEpisodeRoute,
 	PublishTermRoute,
+	GetDiscoveryScheduleRoute,
+	PutDiscoveryScheduleRoute,
 	PushSubscriptionRoute,
 	RenamePodcastRoute,
 	RunSearchIndexerRoute,
@@ -304,6 +306,8 @@ openapi.get('/discovery-info', GetDiscoveryInfoRoute);
 openapi.post('/searchindex/run', RunSearchIndexerRoute);
 openapi.post('/publish/homepage', PublishHomepageRoute);
 openapi.post('/terms', PublishTermRoute);
+openapi.get('/discovery-schedule', GetDiscoveryScheduleRoute);
+openapi.put('/discovery-schedule', PutDiscoveryScheduleRoute);
 openapi.post('/podcast/name/:name', RenamePodcastRoute);
 openapi.post('/pushsubscription', PushSubscriptionRoute);
 openapi.get('/pagedetails/:podcastName/:episodeId', GetPageDetailsRoute);

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -27,6 +27,7 @@ import { publicGetEpisode } from "./publicGetEpisode";
 import { publishPodcastEpisode } from "./publish";
 import { publishHomepage } from "./publishHomepage";
 import { publishTerm } from "./publishTerm";
+import { getDiscoverySchedule, putDiscoverySchedule } from "./discoverySchedule";
 import { pushSubscription } from "./pushSubscription";
 import { renamePodcast } from "./renamePodcast";
 import { runSearchIndexer } from "./runSearchIndexer";
@@ -393,6 +394,25 @@ export const PublishTermRoute = createOpenApiRoute(publishTerm, {
         summary: "Publish term",
         request: { body: jsonBodySchema },
         responses: { 200: { description: "Term published", ...contentJson(genericOkSchema) }, ...authResponses }
+    }
+});
+
+export const GetDiscoveryScheduleRoute = createOpenApiRoute(getDiscoverySchedule, {
+    auth: true,
+    schema: {
+        tags: ["Discovery"],
+        summary: "Get Discovery UK schedule",
+        responses: { 200: { description: "Schedule", ...contentJson(genericOkSchema) }, ...authResponses }
+    }
+});
+
+export const PutDiscoveryScheduleRoute = createOpenApiRoute(putDiscoverySchedule, {
+    auth: true,
+    schema: {
+        tags: ["Discovery"],
+        summary: "Update Discovery UK schedule",
+        request: { body: jsonBodySchema },
+        responses: { 200: { description: "Schedule updated", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
 


### PR DESCRIPTION
## Summary
- Proxy `GET`/`PUT` `/discovery-schedule` to api-infra.
- Wire `secureDiscoveryScheduleEndpoint` and OpenAPI routes for the admin Discovery Schedule UI.

## Test plan
- [ ] Set `secureDiscoveryScheduleEndpoint` in Worker env (local `.dev.vars` / production secrets) to api-infra discovery-schedule.
- [ ] With Auth0 admin token: GET returns schedule; PUT updates and round-trips.
- [ ] Unauthenticated requests return 401/403 as for other secure admin routes.

Made with [Cursor](https://cursor.com)