### PR TITLE
chore: code-quality waves 1–3 (Api worker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,13 @@ podcasts.sql
 /wrangler.toml
 /queries.cmd
 .dev.vars
+.env
+.env.*
+!.env.example
 subjects.json
 flairs.json
 homepage.json
 homepage-ssr.json
-scripts/set-secrets-*.cmd
-scripts/set-secrets-*.ps1
+scripts/local-secrets.*.env
+!scripts/local-secrets.*.env.example
 .cert/

--- a/docs/code-quality-audit-backlog.md
+++ b/docs/code-quality-audit-backlog.md
@@ -1,0 +1,9 @@
+# Code quality audit — ranked backlog
+
+Canonical cross-project backlog (Phase 2 Top 15 + Wave 1–3 checklists):
+
+[`cultpodcasts/RedditPodcastPoster/docs/code-quality-audit-backlog.md`](../../cultpodcasts/RedditPodcastPoster/docs/code-quality-audit-backlog.md)
+
+## Api secrets (Wave 1 correction)
+
+Plaintext secrets / Azure Function endpoint URLs were removed from tracked `set-secrets-*.ps1` scripts. Values live in gitignored `scripts/local-secrets.*.env` (see [worker-secrets.md](./worker-secrets.md)).

--- a/docs/code-quality-audit-phase1.md
+++ b/docs/code-quality-audit-phase1.md
@@ -1,0 +1,102 @@
+# Api Worker — Phase 1 Identify (code quality audit)
+
+**Project:** C — Cloudflare Api Worker (`C:\Users\jonbr\source\repos\Api`)  
+**Scope:** Identify only (no Wave 1–3 implementation)  
+**Date:** 2026-07-22  
+**Scorecard:** `value = (prod_risk × change_frequency × confidence_gain) / effort` (factors 1–5 integers)
+
+---
+
+## Hypotheses confirmed / refuted
+
+| Plan hypothesis | Verdict | Evidence |
+|-----------------|---------|----------|
+| ~26 near-identical Azure proxy handlers | **Confirmed** (~26 Azure `getEndpoint`/`fetch` proxy handlers; 28 files with Azure/Search fetch including `search.ts` + `getPageDetails.ts`) | Pattern repeated across e.g. `src/updateEpisode.ts`, `src/submitDiscovery.ts`, `src/getDiscoveryReports.ts`, `src/deleteEpisode.ts`, …; shared `LogCollector` + `AddResponseHeaders` + permission check + `fetch` + status branch + generic 500/403 |
+| Zero tests | **Confirmed** | No `*.test.ts` / `*.spec.ts`; `package.json` has only `deploy` + `start` (no `test` / `lint`) |
+| `AddResponseHeaders` Allow-Methods bug | **Confirmed** | `src/AddResponseHeaders.ts:20` — `x.toUpperCase` missing `()`; joins function objects into header value |
+| `LogCollector` ASN typo | **Confirmed** | `src/LogCollector.ts:50` — `hasOwnProperty('asn)')` (extra `)`); ASN from `collectRequest` never applied via `add()` |
+| 401 vs 403 inconsistency | **Confirmed** | Most auth failures → **403** + `"Unauthorised"`; R2 list handlers (`getSubjects`, `getFlairs`, `getLanguages`, `getDiscoveryInfo`, `getPeople`) → **401**; OpenAPI `authResponses` documents **403** as `"Unauthorized"` (`src/openapiRoutes.ts:78-82`); docs gate uses 403 for both missing auth and non-admin (`src/index.ts:131-134`) |
+| Analytics Engine bound but unused | **Confirmed** | Binding in `wrangler.jsonc` (all envs) + `Env.Analytics`; **no** `writeDataPoint` / `c.env.Analytics` usage in `src/` |
+| Dual Old/New episode routes | **Confirmed** | `src/index.ts:277-289` registers both `/episode/:podcast…` and `/episode/:id` families |
+| Secrets plaintext in set-secret scripts | **Confirmed** | `scripts/set-secrets-production.ps1` (and preview twin) embed Azure Search `apikey`, Auth0 client id, and endpoint URLs in-repo |
+| `compatibility_date` stale (`2024-09-02`) | **Confirmed** | `wrangler.jsonc:6` |
+
+---
+
+## TOP 10 findings (ranked by value)
+
+| # | lens | finding | evidence path(s) | prod_risk | change_freq | confidence_gain | effort | value | wave | fix type |
+|---|------|---------|------------------|-----------|---------------|-----------------|--------|-------|------|----------|
+| 1 | missing behavior tests | **No behavior-test harness** — zero route/contract tests; critical gateway journeys unguarded | `package.json` (no test script); repo-wide absence of `*.test.ts`/`*.spec.ts`; journeys below | 5 | 5 | 5 | 3 (M) | **41.7** | 2 | Add Vitest + `@cloudflare/vitest-pool-workers`; first suite for auth/CORS/discovery/status/bookmarks/submit |
+| 2 | badly written | **`AddResponseHeaders` Allow-Methods bug** — `toUpperCase` not invoked; ACA-Methods header garbage on responses that use this helper | `src/AddResponseHeaders.ts:20`; callers pass `methods: [...]` across proxies/R2/homepage | 3 | 2 | 5 | 1 (S) | **30.0** | 1 | One-line fix `x.toUpperCase()` (+ assert header); note Hono `corsOptions` already lists methods correctly for preflight |
+| 3 | badly written | **Most Azure proxies collapse non-success to generic 500** — loses 400/404/409 from Azure (esp. discovery-curation GET/POST only accept 200) | `src/submitDiscovery.ts:26-33`; `src/getDiscoveryReports.ts:28-35`; ~22× `return c.json({ error: "Error" }, 500)`; contrast: `src/publicGetEpisode.ts:28-33` and `src/getEpisode.ts:30-33` forward 404 | 4 | 4 | 5 | 3 (M) | **26.7** | 2 | Status allowlist / forward mapping inside shared proxy helper; cover with Vitest |
+| 4 | badly written | **401 vs 403 (and OpenAPI labels) inconsistent** — same “Unauthorised” meaning; clients cannot rely on status | 403: majority of proxies + bookmarks; 401: `src/getSubjects.ts:36`, `src/getFlairs.ts:36`, `src/getLanguages.ts:36`, `src/getDiscoveryInfo.ts:42`, `src/getPeople.ts:113`; OpenAPI: `src/openapiRoutes.ts:78-82`; docs: `src/index.ts:131-134` | 3 | 4 | 4 | 2 (S) | **24.0** | 1 | Normalize: 401 unauthenticated / 403 missing permission; align OpenAPI `authResponses` |
+| 5 | tech debt | **No `test` / `lint` scripts** — no CI gate for Worker quality | `package.json:5-8` | 2 | 3 | 4 | 1 (S) | **24.0** | 2 | Add `test`/`lint` scripts with Vitest (+ eslint/tsc); wire CI when harness exists |
+| 6 | tech debt | **Secrets plaintext in set-secret scripts** — Azure Search API key and Auth0 client id checked into git | `scripts/set-secrets-production.ps1`; `scripts/set-secrets-preview.ps1` (+ `.cmd` wrappers) | 5 | 2 | 4 | 2 (S) | **20.0** | 1 | Remove secrets from repo; load from Key Vault / env / `wrangler secret` interactive; rotate Search key |
+| 7 | badly written | **`LogCollector` ASN never recorded** — typo `'asn)'` breaks `hasOwnProperty` check | `src/LogCollector.ts:50-52`; set path `src/LogCollector.ts:11` | 2 | 2 | 4 | 1 (S) | **16.0** | 1 | Fix key to `'asn'`; assert in unit test |
+| 8 | code smells | **~26 copy-paste Azure proxy handlers** — permission + fetch + status + logging duplicated; `any` JSON bodies | 26 proxy modules under `src/*` using `getEndpoint`/`buildFetchHeaders`; `data: any` in update/create/submit handlers; dual episode handlers in `src/getEpisode.ts`, `src/updateEpisode.ts`, `src/deleteEpisode.ts` | 3 | 5 | 4 | 4 (L) | **15.0** | 3 | Extract `proxyToAzure({ permission, endpoint, expectedStatuses })`; retire old episode routes after client cutover |
+| 9 | unused framework features | **Workers modernization gap** — Analytics Engine bound unused; Vitest Workers pool not adopted; `compatibility_date` stuck at `2024-09-02` | `src/Env.ts:28`; `wrangler.jsonc` `analytics_engine_datasets` + `compatibility_date`; no vitest deps in `package.json` | 2 | 3 | 4 | 3 (M) | **8.0** | 2 | Adopt Vitest pool (with finding #1); either use Analytics or drop binding; bump compatibility_date deliberately |
+| 10 | code smells | **Weak OpenAPI contracts (`z.any`) + dual Old/New episode surface** — docs/schemas don’t constrain bodies; two episode URL families to maintain | `src/openapiRoutes.ts:68-76` (`genericOkSchema` / `jsonBodySchema`); `src/index.ts:277-289` | 2 | 4 | 3 | 3 (M) | **8.0** | 3 | Tighten Zod schemas incrementally; deprecate old `/episode/:id` after Angular uses new routes |
+
+**Scoring notes**
+
+- Finding #2: Hono `cors` middleware (`src/corsOptions.ts`) already handles OPTIONS correctly; the bug still pollutes `Access-Control-Allow-Methods` on many non-preflight responses.
+- Finding #8 effort **L** because safe extraction depends on Wave 2 status/auth tests (#1, #3).
+- Effort column: numeric 1–5 used in formula; parenthetical S/M/L is planning size.
+
+---
+
+## Additional confirmed issues (outside top 10, for Phase 2 merge)
+
+| Issue | Evidence | Notes |
+|-------|----------|-------|
+| `pushSubscription` may throw if JWT has no `permissions` | `src/pushSubscription.ts:14` — `auth0Payload.permissions.includes` without `?.` | Unauthenticated path OK; malformed payload → unhandled error |
+| Auth0 middleware never returns 401 on invalid/missing JWT | `src/Auth0Middleware.ts:13-26` — sets empty `auth0` callback and `next()` | Failures deferred to handlers (403/401 mix) |
+| OpenAPI docs auth: missing token labeled Unauthorised **403** | `src/index.ts:127-131` | Same 401/403 theme |
+| `publicGetEpisode` requires Auth0 payload despite “public” path | `src/publicGetEpisode.ts:17-42`; route `auth: true` in `openapiRoutes.ts` | Name vs gate mismatch — cover in auth matrix |
+
+---
+
+## Vitest Workers pool — journey map
+
+Target stack: **Vitest** + **`@cloudflare/vitest-pool-workers`** (plan Project C). No tests exist today; this is the Wave 2 harness backlog.
+
+| Journey | Risk if broken | Suggested cases | Primary files |
+|---------|----------------|-----------------|---------------|
+| **Auth permission matrix** | High — curation/admin/submit leakage or lockout | No bearer → 401 (after normalize); valid JWT missing scope → 403; `curate` / `admin` / `submit` allow respective routes; invalid JWT does not elevate; docs `/openapi.json` requires admin | `Auth0Middleware.ts`, handlers’ `permissions.includes`, `openapiRoutes.ts` `auth: true`, `index.ts` docs gate |
+| **CORS allowlist** | High — browser client blocked or overly open | Allowed origins (`AllowedOrigins` + `stagingHostSuffix`) reflected; disallowed origin falls back to primary allowlist origin; preflight `OPTIONS` allows GET/POST/PUT/DELETE + `authorization`; credentials true | `corsOptions.ts`, `getOrigin.ts`, `AllowedOrigins.ts`, `index.ts` `app.use('/*', cors(...))` |
+| **Discovery-curation GET/POST status forwarding** | High — curator UI treats Azure 4xx as Worker 500 | GET `/discovery-curation` with `curate`: Azure 200 body forwarded; Azure 4xx/5xx **not** remapped to opaque 500 (today they are); POST `/discovery-curation` same; query string forwarded on GET | `getDiscoveryReports.ts`, `submitDiscovery.ts`, `endpoints.ts` |
+| **Status forwarding (episode / public)** | Medium-High — bookmarks/UI miss vs hard fail | `GET /public/episode/:id` forwards **404**; `GET /episode/...` forwards **404**; non-404 failures → controlled error; regression: do not reintroduce 500-for-404 | `publicGetEpisode.ts`, `getEpisode.ts` |
+| **Bookmarks Durable Object** | High — user profile data wrong/lost | Authed `sub`: add → 200; duplicate → 409; invalid UUID → 400; get empty user → `[]` 200; delete missing → documented status; unauth → 401/403 per policy | `addBookmark.ts`, `deleteBookmark.ts`, `getBookmarks.ts`, `ProfileDurableObject.ts` |
+| **Submit Azure-vs-D1 fallback** | High — lost submissions or wrong success | `submit` scope + Azure 200 → body + `X-Origin: true`; Azure non-200 → D1 insert success; missing/invalid URL → 400; Prisma unique/error → 400; unauth without Azure success still D1 path (document intended behavior) | `submit.ts` |
+
+### Suggested first Vitest file set (Wave 2)
+
+1. `tests/auth-matrix.spec.ts`
+2. `tests/cors.spec.ts`
+3. `tests/discovery-curation.spec.ts`
+4. `tests/status-forwarding.spec.ts`
+5. `tests/bookmarks-do.spec.ts`
+6. `tests/submit-fallback.spec.ts`
+
+---
+
+## Proposed wave assignment (Api-only preview)
+
+| Wave | Theme | Findings |
+|------|--------|----------|
+| **1** | Quick wins / proven bugs | #2 Allow-Methods `()`, #4 401/403 normalize, #6 secrets out of repo (+ rotate), #7 ASN typo |
+| **2** | Behavior-test harness + status contracts | #1 Vitest pool, #5 test/lint scripts, #3 status forwarding, #9 compatibility/Analytics decision |
+| **3** | Structural | #8 `proxyToAzure` helper, #10 OpenAPI schemas + deprecate old episode routes |
+
+---
+
+## Method / lens coverage checklist
+
+| Lens | Covered by finding # |
+|------|----------------------|
+| 1. Code smells | 8, 10 |
+| 2. Technical debt | 5, 6 |
+| 3. Badly written | 2, 3, 4, 7 |
+| 4. Unused framework features | 9 (Analytics unused; Vitest pool missing; stale compatibility_date) |
+| 5. Missing behavior tests | 1 (+ journey map) |

--- a/docs/follow-ons-decisions.md
+++ b/docs/follow-ons-decisions.md
@@ -1,0 +1,38 @@
+# Api Worker — follow-on decisions
+
+Short decision notes for Wave 2+ code-quality items that need an explicit choice before implementation.
+
+---
+
+## Analytics Engine binding (2026-07-23)
+
+**Current state:** `analytics_engine_datasets` with binding `Analytics` is declared in `wrangler.jsonc` (default + `local` / `preview` / `production` envs). `Env.Analytics: AnalyticsEngineDataset` is typed in `src/Env.ts`. **No** `writeDataPoint` or other runtime usage exists under `src/`.
+
+**Observability already enabled:** `wrangler.jsonc` sets `"observability": { "enabled": true }`, which covers Workers Logs / tracing for production debugging without a custom Analytics Engine dataset.
+
+**Recommendation: drop the binding (do not add usage yet).**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Drop binding** (recommended) | Removes dead config and unused `Env` surface; one less binding to reason about in local/preview/prod | If product later wants custom SQL analytics (e.g. per-route latency histograms), binding must be re-added |
+| Add `writeDataPoint` usage | Custom queryable metrics in AE SQL | Needs schema design, sampling, PII review, and ongoing cost; duplicates what App Insights / Workers observability already provide for this gateway |
+
+**Action when approved:** Remove `analytics_engine_datasets` blocks from all envs in `wrangler.jsonc` and remove `Analytics` from `Env.ts`. No deploy urgency — binding is inert today.
+
+---
+
+## `compatibility_date` (2026-07-23)
+
+**Current value:** `2024-09-02` (`wrangler.jsonc:6`)
+
+**Proposed value (if bumping deliberately):** `2026-01-01` or latest stable date at time of intentional Workers-runtime review — **not** auto-bumped in this wave.
+
+**Recommendation: leave at `2024-09-02` for now; schedule a deliberate bump with a test pass.**
+
+| Factor | Assessment |
+|--------|------------|
+| Risk of staying | Low — worker uses Hono, JWT, R2, D1, DO; no exotic runtime flags pinned to newer dates |
+| Risk of bumping | Medium — compatibility date gates runtime bugfixes and API behaviour changes; a jump of ~18 months can alter fetch, crypto, or streaming semantics |
+| When to bump | After a dedicated regression pass (`npm test`, manual smoke of auth/CORS/discovery/bookmarks/submit) on `wrangler dev` with candidate date |
+
+**Do not bump** as part of unrelated schema/docs work. Treat as its own small PR with changelog review against [Workers compatibility dates](https://developers.cloudflare.com/workers/configuration/compatibility-dates/).

--- a/docs/openapi-schemas-from-csharp.md
+++ b/docs/openapi-schemas-from-csharp.md
@@ -1,0 +1,110 @@
+# Generating OpenAPI Zod schemas from C# DTOs
+
+The Cloudflare Api worker (`src/openapiSchemas.ts` + `src/openapiRoutes.ts`) documents JSON that **api-infra** (Azure Functions) and a few worker-local routes actually return or accept.
+
+There is **no automated codegen today**. “Generate” means: copy the C# contract into a **strict** Zod object, wire it on the route, add a Vitest parse test, then deploy. Do **not** use `.passthrough()`, `z.any()`, or `z.record(z.string(), z.unknown())` for known DTOs — Swagger renders those as `additionalProp1/2/3`.
+
+## Source of truth (C#)
+
+Repo: `cultpodcasts/RedditPodcastPoster`
+
+| Kind | Path |
+|------|------|
+| Response DTOs | `Cloud/Api/Dtos/*.cs` |
+| Request / change models | `Cloud/Api/Models/*ChangeRequest*.cs`, `*Request*.cs` |
+| Shared domain shapes | `Class-Libraries/RedditPodcastPoster.Models/**` (e.g. `ServiceUrls`, `ServiceImageUrls`, `Service`, `SubjectType`) |
+| Search index hit | `Class-Libraries/RedditPodcastPoster.Search/Models/EpisodeSearchRecord.cs` |
+| R2 publish models | `Class-Libraries/RedditPodcastPoster.ContentPublisher/Models/` (e.g. `DiscoveryInfo`) |
+| Status codes | Handlers under `Cloud/Api/Handlers/**` + thin CF proxies in `Api/src/*.ts` (`successStatuses` / `forwardStatuses`) |
+
+Worker-only (no Functions DTO): bookmarks Durable Object, R2 `subjects` name list, `getPageDetails` (`IPageDetails`), Azure Search envelope wrapping `EpisodeSearchRecord`.
+
+## Workflow
+
+1. **Find the C# type** for the route (handler → DTO / change request).
+2. **Read `[JsonPropertyName("…")]`** — Zod keys must match JSON names, not C# property names (`BlueskyPosted` → `bluesky`, `Language` → `lang`, `Length` → `duration`).
+3. **Map types** (table below) into a new `export const …Schema = z.object({ … })` in `src/openapiSchemas.ts`. Cite the C# type in a short JSDoc (`/** Api.Dtos.EpisodeDto */`).
+4. **Wire** the schema in `src/openapiRoutes.ts` on the matching route: success status + error statuses the worker actually forwards (`proxyToAzure` options or handler returns).
+5. **Test** in `tests/openapi-schemas.spec.ts` with a minimal valid fixture (and a reject case for enums if useful).
+6. **Verify**: `npm test` && `npm run lint`. Optionally hard-refresh Swagger on `api.cultpodcasts.com` after deploy.
+
+## Type mapping
+
+| C# | Zod | Notes |
+|----|-----|--------|
+| `string` / `string?` | `z.string()` / `.optional().nullable()` | |
+| `bool` / `bool?` | `z.boolean()` / `.optional().nullable()` | |
+| `int` / `long` / `Guid` | `z.number().int()` / `z.string().uuid()` | Guids are JSON strings |
+| `DateTime` / `DateTimeOffset` | `z.string()` | ISO-8601 from System.Text.Json |
+| `TimeSpan` | `z.string()` | e.g. `"01:30:00"` |
+| `Uri?` (response) | `z.string().url().optional().nullable()` | |
+| `Uri?` on **change requests** | `z.union([z.string().url(), z.literal(""), z.null()]).optional()` | Angular clears URLs with `""` |
+| `[JsonConverter(typeof(JsonStringEnumConverter))] enum` | `z.enum(["A", "B", …])` | Use **enum member names**, not numeric values (`Service`, `SubjectType`, `SearchIndexerState`) |
+| Nested class / record | Nested `z.object({ … })` | Prefer a shared export (`serviceUrlsSchema`) when reused |
+| Arrays | `z.array(…)` | |
+| Empty body | `z.object({})` or omit body | e.g. publish homepage sends `"{}"` |
+
+### Shared enums already in the worker
+
+```ts
+serviceEnumSchema     // Spotify | Apple | YouTube | Other
+subjectTypeSchema     // Unset | Canonical | Meta
+searchIndexerStateSchema // EpisodeNotFound | … | Unknown
+```
+
+Reuse these on both request and response schemas.
+
+## Status codes
+
+OpenAPI `responses` must match what the **worker** returns, not only Azure:
+
+1. Read CF handler (`successStatuses`, `forwardStatuses`, `passthroughOtherStatuses`) or R2/DO logic.
+2. Cross-check Azure handler (`ctx.Ok` / `Accepted` / `NotFound` / …).
+3. Always document worker auth: **401** / **403** via shared `authResponses` + `errorSchema`.
+
+Common mismatches to avoid:
+
+| Wrong in Swagger | Correct (api-infra) |
+|------------------|---------------------|
+| Episode update **200** | **202** + `EpisodeUpdateResponse` |
+| Podcast/person/subject update **200** | **202** |
+| Opaque success | Concrete DTO / empty description for empty body |
+
+## Anti-patterns (cause `additionalProp1/2/3`)
+
+| Avoid | Use instead |
+|-------|-------------|
+| `.passthrough()` on known DTOs | Strict `z.object({ … })` with only known keys |
+| `z.record(z.string(), z.unknown())` / `z.any()` | Named fields from C# |
+| `z.string()` for string enums | `z.enum([...])` |
+| `serviceUrlsSchema` (`.url()` only) on **PATCH** bodies | Patch URI union allowing `""` |
+| Inventing fields not on the DTO | Only `[JsonPropertyName]` members (plus documented worker-only extras if any) |
+
+`z.record` is OK only for true dynamic maps (R2 flairs keyed by Guid, languages code→name).
+
+## Checklist for a new / changed Azure DTO
+
+- [ ] Schema keys match `[JsonPropertyName]`
+- [ ] Enums use `z.enum` of member names
+- [ ] No `.passthrough()` / opaque record on this DTO
+- [ ] Route success + forwarded error codes updated in `openapiRoutes.ts`
+- [ ] Vitest accepts a realistic fixture; rejects invalid enum if applicable
+- [ ] JSDoc points at the C# type path
+- [ ] `npm test` && `npm run lint`
+
+## Example: episode change request
+
+C#: `Cloud/Api/Models/EpisodeChangeRequest.cs` → JSON `bluesky`, `lang`, `urls` (`ServiceUrls`), `images` (`ServiceImageUrls`).
+
+Worker: `episodeChangeRequestSchema` in `src/openapiSchemas.ts`, used by update-episode routes in `openapiRoutes.ts`.
+
+## Related files
+
+| File | Role |
+|------|------|
+| `src/openapiSchemas.ts` | Zod schemas |
+| `src/openapiRoutes.ts` | Chanfana route OpenAPI (status + schema) |
+| `tests/openapi-schemas.spec.ts` | Schema parse contracts |
+| `src/proxyToAzure.ts` | Runtime status forwarding for Azure proxies |
+
+When Azure DTO shapes change in RedditPodcastPoster, update the Zod schema in the same PR wave as the Functions deploy (or immediately after) so Swagger on `api.cultpodcasts.com` stays honest.

--- a/docs/worker-secrets.md
+++ b/docs/worker-secrets.md
@@ -1,0 +1,37 @@
+# Cloudflare Worker secrets (Api)
+
+Worker secrets (Search API key, Auth0 client id, Azure Function endpoint URLs, etc.) must **never** be committed to git.
+
+## Preferred pattern
+
+1. Copy the tracked example file:
+   - Preview: `scripts/local-secrets.preview.env.example` → `scripts/local-secrets.preview.env`
+   - Production: `scripts/local-secrets.production.env.example` → `scripts/local-secrets.production.env`
+2. Fill real values in the `.env` copy (gitignored).
+3. Run:
+   - `.\scripts\set-secrets-preview.ps1` or `scripts\set-secrets-preview.cmd`
+   - `.\scripts\set-secrets-production.ps1` or `scripts\set-secrets-production.cmd`
+
+The scripts read `KEY=VALUE` lines and pipe each value to `npx wrangler secret put <KEY> --env <preview|production>`.
+
+Process environment variables with the same key names override file values if set.
+
+## Local Wrangler / Pages vars
+
+- `.dev.vars` — local Worker secrets for `wrangler dev` (gitignored).
+- `.env` — also gitignored; do not commit.
+
+## Gitignore
+
+These paths are ignored (do not track):
+
+- `.dev.vars`
+- `.env`
+- `.env.*` (except `*.example` if added later under scripts)
+- `scripts/local-secrets.*.env` (real values only; `*.env.example` is tracked)
+
+Tracked scripts (`set-secrets-*.ps1` / `.cmd`) contain **no** real secrets or `*.azurewebsites.net` hosts — only loaders and placeholder examples.
+
+## After a historical plaintext leak
+
+Rotate the Azure Cognitive Search API key (and any other exposed credentials) in Azure / Auth0, then re-run the set-secrets script from your local file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,10 @@
         "prisma": "^5.13.0"
       },
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.18.7",
         "@cloudflare/workers-types": "^4.20241022.0",
         "typescript": "^5.0.4",
+        "vitest": "^4.1.0",
         "wrangler": "^4.67.0"
       }
     },
@@ -80,6 +82,740 @@
         "workerd": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.18.7.tgz",
+      "integrity": "sha512-PGYToiFoGpuRV2Uh33S4fI7JcmSkDxk6LQeneYtgfsITEkVi5iGxc3Vms6yW9Jr6uSzVK4Be9XZfdyZDr5GWYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "1.2.3",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260721.0",
+        "wrangler": "4.113.0",
+        "zod": "3.25.76"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260721.1.tgz",
+      "integrity": "sha512-VivNMhiEdZIB4JBWxf1RMJGROErv53qmQ+dvhjA1evrCouvqRYW718VqDideU3PSV7Ythl5Df48NqZYWoaEHpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260721.1.tgz",
+      "integrity": "sha512-k7oye1ZiuwnnBBA2eTMduconr/ud5ZxFtRNTsYwMdmJeeeislw2+M72otrHxxvybCP7JWPPlJ38uhfajpcyhOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260721.1.tgz",
+      "integrity": "sha512-hon0lW4ZQ4boAVgaw+0ZFTNS8v5MWPWvK0HZnt4tDpKYnDUviLZawtUW3KqvFmCQTipVHl1S34j3J8Eqb93hGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260721.1.tgz",
+      "integrity": "sha512-nAl+HRQqpX5b7xVwWcvLPZmCk8NQ2yjI0yvJTWcHiRswbMEg1ZZckVmjJUAn0PHzZARbCSyIV7v3UjM+SPRmIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260721.1.tgz",
+      "integrity": "sha512-9paFG5cMTKz/CRixnEEnZbe5uvFPBFSDthxJHANfCWhUtBj49GSL1FPIokIg+Q+H8DGJEExU0lL92LtxD0lTxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare": {
+      "version": "4.20260721.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260721.0.tgz",
+      "integrity": "sha512-fBLaCxZ2i/nPH8iyLzvza0C8/sSF4sjD1ma1Skf+pkZVK0TlaW5ujHJlUHwcwR66v2JZt+Q28d4DCX/oaLG0cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260721.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/workerd": {
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260721.1.tgz",
+      "integrity": "sha512-b/DWhpV0jTudzQpLhDovcOgBz233386q+3Hbari7CLCNT9UXxjQziSTZ9yCoKdT2K3TSx5jrwlOisq8hlLWXYg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260721.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260721.1",
+        "@cloudflare/workerd-linux-64": "1.20260721.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260721.1",
+        "@cloudflare/workerd-windows-64": "1.20260721.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "4.113.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.113.0.tgz",
+      "integrity": "sha512-ROGzSloJv0y21It6Oc9LaruNcu1tdiQ/XzL3Jc3YkFjzXEMXzTqVhA8vQaGMTdZHTjFP0PVcwAHNgaw3gXu4wA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260721.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260721.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260721.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -187,10 +923,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1158,6 +1917,35 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
@@ -1275,6 +2063,288 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -1295,11 +2365,209 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
@@ -1307,6 +2575,16 @@
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chanfana": {
       "version": "3.0.0",
@@ -1323,6 +2601,20 @@
       "bin": {
         "chanfana": "dist/cli.js"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -1357,6 +2649,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1398,6 +2697,44 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fsevents": {
@@ -1445,6 +2782,289 @@
         "node": ">=6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/miniflare": {
       "version": "4.20260219.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260219.0.tgz",
@@ -1464,6 +3084,39 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/openapi3-ts": {
@@ -1489,6 +3142,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prisma": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
@@ -1513,6 +3215,40 @@
       "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
       "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
       "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -1572,6 +3308,37 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -1583,6 +3350,50 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1625,6 +3436,241 @@
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",
-    "start": "wrangler dev --env local --ip 127.0.0.1 --port 8787 --local-protocol https --https-cert-path ./.cert/dev-cert.pem --https-key-path ./.cert/dev-key.pem"
+    "start": "wrangler dev --env local --ip 127.0.0.1 --port 8787 --local-protocol https --https-cert-path ./.cert/dev-cert.pem --https-key-path ./.cert/dev-key.pem",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.18.7",
     "@cloudflare/workers-types": "^4.20241022.0",
     "typescript": "^5.0.4",
+    "vitest": "^4.1.0",
     "wrangler": "^4.67.0"
   },
   "dependencies": {

--- a/scripts/local-secrets.preview.env.example
+++ b/scripts/local-secrets.preview.env.example
@@ -1,0 +1,27 @@
+# Copy to local-secrets.preview.env (gitignored) and fill real values.
+# Never commit local-secrets.*.env — only this .example file is tracked.
+#
+# Then run: .\scripts\set-secrets-preview.ps1
+
+apihost=https://YOUR_SEARCH.search.windows.net/indexes/YOUR_INDEX/docs/search?api-version=2016-09-01
+apikey=YOUR_AZURE_SEARCH_API_KEY
+auth0Audience=https://api.example.com/
+auth0Issuer=https://auth-staging.example.com/
+overrideHost=
+secureAdminPublishHomepageEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/publish/homepage
+secureAdminSearchIndexerEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/searchindex/run
+secureAdminTermsEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/terms
+secureDiscoveryCurationEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/DiscoveryCuration
+secureDiscoveryScheduleEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/discovery-schedule
+secureEpisodeEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/episode
+secureEpisodePublishEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/episode/publish/
+secureEpisodesOutgoingEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/episodes/outgoing
+securePodcastEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/podcast
+securePodcastIndexEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/podcast/index
+securePublicEpisodeEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/public/episode
+securePushSubscriptionEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/pushsubscription
+secureSubjectEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/subject
+securePeopleEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/people
+secureSubmitEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/SubmitUrl
+stagingHostSuffix=your-pages-preview.pages.dev
+auth0ClientId=YOUR_AUTH0_SPA_CLIENT_ID

--- a/scripts/local-secrets.production.env.example
+++ b/scripts/local-secrets.production.env.example
@@ -1,0 +1,27 @@
+# Copy to local-secrets.production.env (gitignored) and fill real values.
+# Never commit local-secrets.*.env — only this .example file is tracked.
+#
+# Then run: .\scripts\set-secrets-production.ps1
+
+apihost=https://YOUR_SEARCH.search.windows.net/indexes/YOUR_INDEX/docs/search?api-version=2016-09-01
+apikey=YOUR_AZURE_SEARCH_API_KEY
+auth0Audience=https://api.example.com/
+auth0Issuer=https://auth.example.com/
+overrideHost=
+secureAdminPublishHomepageEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/publish/homepage
+secureAdminSearchIndexerEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/searchindex/run
+secureAdminTermsEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/terms
+secureDiscoveryCurationEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/DiscoveryCuration
+secureDiscoveryScheduleEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/discovery-schedule
+secureEpisodeEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/episode
+secureEpisodePublishEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/episode/publish/
+secureEpisodesOutgoingEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/episodes/outgoing
+securePodcastEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/podcast
+securePodcastIndexEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/podcast/index
+securePublicEpisodeEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/public/episode
+securePushSubscriptionEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/pushsubscription
+secureSubjectEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/subject
+securePeopleEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/people
+secureSubmitEndpoint=https://YOUR_FUNCTION_APP.azurewebsites.net/api/SubmitUrl
+stagingHostSuffix=your-pages-preview.pages.dev
+auth0ClientId=YOUR_AUTH0_SPA_CLIENT_ID

--- a/scripts/set-secrets-preview.cmd
+++ b/scripts/set-secrets-preview.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+
+REM Delegates to PowerShell. Secrets/endpoints come from
+REM scripts\local-secrets.preview.env (gitignored) — see docs\worker-secrets.md
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0set-secrets-preview.ps1"
+exit /b %ERRORLEVEL%

--- a/scripts/set-secrets-preview.ps1
+++ b/scripts/set-secrets-preview.ps1
@@ -1,0 +1,120 @@
+# Sets Cloudflare Worker secrets for the preview env via wrangler.
+#
+# NEVER put real secrets or Azure Function endpoint URLs in this script.
+# Load them from a gitignored local file (preferred) or process env vars.
+#
+# Preferred: copy the example and fill real values locally:
+#   copy scripts\local-secrets.preview.env.example scripts\local-secrets.preview.env
+#   .\scripts\set-secrets-preview.ps1
+#
+# File format (KEY=VALUE, one wrangler secret name per line):
+#   apikey=...
+#   auth0ClientId=...
+#   secureEpisodeEndpoint=https://....azurewebsites.net/api/episode
+#   ...
+#
+# Optional: process env vars override file values (same KEY names).
+# Rotate Azure Search keys after any historical plaintext commit of apikey.
+#
+# See docs/worker-secrets.md
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$envName = 'preview'
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$secretsFile = Join-Path $PSScriptRoot 'local-secrets.preview.env'
+
+function Import-DotEnvFile([string]$Path) {
+    $map = [ordered]@{}
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $map
+    }
+    foreach ($raw in Get-Content -LiteralPath $Path) {
+        $line = $raw.Trim()
+        if ($line -eq '' -or $line.StartsWith('#')) { continue }
+        $eq = $line.IndexOf('=')
+        if ($eq -lt 1) {
+            throw "Invalid line in $Path (expected KEY=VALUE): $raw"
+        }
+        $key = $line.Substring(0, $eq).Trim()
+        $value = $line.Substring($eq + 1).Trim()
+        if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+            $value = $value.Substring(1, $value.Length - 2)
+        }
+        $map[$key] = $value
+    }
+    return $map
+}
+
+function Get-SecretValue([string]$Name, [System.Collections.IDictionary]$FromFile) {
+    # Env var wins when set (including empty). Otherwise require the key in the local file.
+    $fromEnv = [Environment]::GetEnvironmentVariable($Name)
+    if ($null -ne $fromEnv) {
+        return $fromEnv
+    }
+    if ($FromFile.Contains($Name)) {
+        return [string]$FromFile[$Name]
+    }
+    throw "Missing secret '$Name'. Set it in '$secretsFile' (gitignored) or as an environment variable with the same name."
+}
+
+if (-not (Test-Path -LiteralPath $secretsFile)) {
+    Write-Warning "Secrets file not found: $secretsFile"
+    Write-Warning "Copy scripts\local-secrets.preview.env.example to scripts\local-secrets.preview.env and fill real values."
+}
+
+Push-Location $repoRoot
+try {
+    $fromFile = Import-DotEnvFile $secretsFile
+
+    # Keys uploaded to wrangler for this env. Values come ONLY from the local file / env.
+    $secretNames = @(
+        'apihost'
+        'apikey'
+        'auth0Audience'
+        'auth0Issuer'
+        'overrideHost'
+        'secureAdminPublishHomepageEndpoint'
+        'secureAdminSearchIndexerEndpoint'
+        'secureAdminTermsEndpoint'
+        'secureDiscoveryCurationEndpoint'
+        'secureDiscoveryScheduleEndpoint'
+        'secureEpisodeEndpoint'
+        'secureEpisodePublishEndpoint'
+        'secureEpisodesOutgoingEndpoint'
+        'securePodcastEndpoint'
+        'securePodcastIndexEndpoint'
+        'securePublicEpisodeEndpoint'
+        'securePushSubscriptionEndpoint'
+        'secureSubjectEndpoint'
+        'securePeopleEndpoint'
+        'secureSubmitEndpoint'
+        'stagingHostSuffix'
+        'auth0ClientId'
+    )
+
+    $mustBeNonEmpty = @(
+        'apihost', 'apikey', 'auth0Audience', 'auth0Issuer',
+        'secureAdminPublishHomepageEndpoint', 'secureAdminSearchIndexerEndpoint', 'secureAdminTermsEndpoint',
+        'secureDiscoveryCurationEndpoint', 'secureDiscoveryScheduleEndpoint',
+        'secureEpisodeEndpoint', 'secureEpisodePublishEndpoint', 'secureEpisodesOutgoingEndpoint',
+        'securePodcastEndpoint', 'securePodcastIndexEndpoint', 'securePublicEpisodeEndpoint',
+        'securePushSubscriptionEndpoint', 'secureSubjectEndpoint', 'securePeopleEndpoint', 'secureSubmitEndpoint',
+        'stagingHostSuffix', 'auth0ClientId'
+    )
+
+    foreach ($name in $secretNames) {
+        $value = Get-SecretValue $name $fromFile
+        if ($mustBeNonEmpty -contains $name -and [string]::IsNullOrWhiteSpace($value)) {
+            throw "Secret '$name' is empty. Fill it in '$secretsFile' before running."
+        }
+        Write-Host "Setting $name for '$envName'..."
+        $value | npx wrangler secret put $name --env $envName
+    }
+
+    Write-Host "Done setting secrets for '$envName'."
+}
+finally {
+    Pop-Location
+}

--- a/scripts/set-secrets-production.cmd
+++ b/scripts/set-secrets-production.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+
+REM Delegates to PowerShell. Secrets/endpoints come from
+REM scripts\local-secrets.production.env (gitignored) — see docs\worker-secrets.md
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0set-secrets-production.ps1"
+exit /b %ERRORLEVEL%

--- a/scripts/set-secrets-production.ps1
+++ b/scripts/set-secrets-production.ps1
@@ -1,0 +1,120 @@
+# Sets Cloudflare Worker secrets for the production env via wrangler.
+#
+# NEVER put real secrets or Azure Function endpoint URLs in this script.
+# Load them from a gitignored local file (preferred) or process env vars.
+#
+# Preferred: copy the example and fill real values locally:
+#   copy scripts\local-secrets.production.env.example scripts\local-secrets.production.env
+#   .\scripts\set-secrets-production.ps1
+#
+# File format (KEY=VALUE, one wrangler secret name per line):
+#   apikey=...
+#   auth0ClientId=...
+#   secureEpisodeEndpoint=https://....azurewebsites.net/api/episode
+#   ...
+#
+# Optional: process env vars override file values (same KEY names).
+# Rotate Azure Search keys after any historical plaintext commit of apikey.
+#
+# See docs/worker-secrets.md
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$envName = 'production'
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$secretsFile = Join-Path $PSScriptRoot 'local-secrets.production.env'
+
+function Import-DotEnvFile([string]$Path) {
+    $map = [ordered]@{}
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $map
+    }
+    foreach ($raw in Get-Content -LiteralPath $Path) {
+        $line = $raw.Trim()
+        if ($line -eq '' -or $line.StartsWith('#')) { continue }
+        $eq = $line.IndexOf('=')
+        if ($eq -lt 1) {
+            throw "Invalid line in $Path (expected KEY=VALUE): $raw"
+        }
+        $key = $line.Substring(0, $eq).Trim()
+        $value = $line.Substring($eq + 1).Trim()
+        if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+            $value = $value.Substring(1, $value.Length - 2)
+        }
+        $map[$key] = $value
+    }
+    return $map
+}
+
+function Get-SecretValue([string]$Name, [System.Collections.IDictionary]$FromFile) {
+    # Env var wins when set (including empty). Otherwise require the key in the local file.
+    $fromEnv = [Environment]::GetEnvironmentVariable($Name)
+    if ($null -ne $fromEnv) {
+        return $fromEnv
+    }
+    if ($FromFile.Contains($Name)) {
+        return [string]$FromFile[$Name]
+    }
+    throw "Missing secret '$Name'. Set it in '$secretsFile' (gitignored) or as an environment variable with the same name."
+}
+
+if (-not (Test-Path -LiteralPath $secretsFile)) {
+    Write-Warning "Secrets file not found: $secretsFile"
+    Write-Warning "Copy scripts\local-secrets.production.env.example to scripts\local-secrets.production.env and fill real values."
+}
+
+Push-Location $repoRoot
+try {
+    $fromFile = Import-DotEnvFile $secretsFile
+
+    # Keys uploaded to wrangler for this env. Values come ONLY from the local file / env.
+    $secretNames = @(
+        'apihost'
+        'apikey'
+        'auth0Audience'
+        'auth0Issuer'
+        'overrideHost'
+        'secureAdminPublishHomepageEndpoint'
+        'secureAdminSearchIndexerEndpoint'
+        'secureAdminTermsEndpoint'
+        'secureDiscoveryCurationEndpoint'
+        'secureDiscoveryScheduleEndpoint'
+        'secureEpisodeEndpoint'
+        'secureEpisodePublishEndpoint'
+        'secureEpisodesOutgoingEndpoint'
+        'securePodcastEndpoint'
+        'securePodcastIndexEndpoint'
+        'securePublicEpisodeEndpoint'
+        'securePushSubscriptionEndpoint'
+        'secureSubjectEndpoint'
+        'securePeopleEndpoint'
+        'secureSubmitEndpoint'
+        'stagingHostSuffix'
+        'auth0ClientId'
+    )
+
+    $mustBeNonEmpty = @(
+        'apihost', 'apikey', 'auth0Audience', 'auth0Issuer',
+        'secureAdminPublishHomepageEndpoint', 'secureAdminSearchIndexerEndpoint', 'secureAdminTermsEndpoint',
+        'secureDiscoveryCurationEndpoint', 'secureDiscoveryScheduleEndpoint',
+        'secureEpisodeEndpoint', 'secureEpisodePublishEndpoint', 'secureEpisodesOutgoingEndpoint',
+        'securePodcastEndpoint', 'securePodcastIndexEndpoint', 'securePublicEpisodeEndpoint',
+        'securePushSubscriptionEndpoint', 'secureSubjectEndpoint', 'securePeopleEndpoint', 'secureSubmitEndpoint',
+        'stagingHostSuffix', 'auth0ClientId'
+    )
+
+    foreach ($name in $secretNames) {
+        $value = Get-SecretValue $name $fromFile
+        if ($mustBeNonEmpty -contains $name -and [string]::IsNullOrWhiteSpace($value)) {
+            throw "Secret '$name' is empty. Fill it in '$secretsFile' before running."
+        }
+        Write-Host "Setting $name for '$envName'..."
+        $value | npx wrangler secret put $name --env $envName
+    }
+
+    Write-Host "Done setting secrets for '$envName'."
+}
+finally {
+    Pop-Location
+}

--- a/src/AddResponseHeaders.ts
+++ b/src/AddResponseHeaders.ts
@@ -17,5 +17,5 @@ export function AddResponseHeaders(c: Context<any>, opts: HttpResponseHeaderOpti
 		c.header("etag", opts.etag);
 	}
 	c.header("Access-Control-Allow-Origin", getOrigin(c.req.header("Origin"), c.env.stagingHostSuffix));
-	c.header("Access-Control-Allow-Methods", opts.methods.map(x => x.toUpperCase).join(","));
+	c.header("Access-Control-Allow-Methods", opts.methods.map(x => x.toUpperCase()).join(","));
 }

--- a/src/LogCollector.ts
+++ b/src/LogCollector.ts
@@ -47,7 +47,7 @@ export class LogCollector implements endpointOperation {
         if (props.hasOwnProperty('clientTrustScoretr')) {
             this.clientTrustScoretr = props.clientTrustScoretr;
         }
-        if (props.hasOwnProperty('asn)')) {
+        if (props.hasOwnProperty('asn')) {
             this.asn = props.asn;
         }
         if (props.hasOwnProperty('ipAddress')) {

--- a/src/createPerson.ts
+++ b/src/createPerson.ts
@@ -1,45 +1,19 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function createPerson(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, { methods: ["POST", "GET", "PUT", "OPTIONS"] });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        const url = getEndpoint(Endpoint.person, c.env);
-        const data: any = await c.req.json();
-        const body: string = JSON.stringify(data);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "PUT",
-            body: body
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 202) {
-            logCollector.addMessage(`Successfully used secure-person-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else if (resp.status == 409) {
-            logCollector.addMessage(`Conflict reported on secure-person-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else if (resp.status == 400) {
-            logCollector.addMessage(`Bad request on secure-person-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else {
-            logCollector.addMessage(`Failed to use secure-person-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage(`Unauthorised to use createPerson.`);
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, { methods: ["POST", "GET", "PUT", "OPTIONS"] });
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.person,
+		method: "PUT",
+		body,
+		successStatuses: [202],
+		forwardStatuses: [409, 400],
+		logName: "secure-person-endpoint"
+	});
 }

--- a/src/createSubject.ts
+++ b/src/createSubject.ts
@@ -1,41 +1,19 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function createSubject(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        const url = getEndpoint(Endpoint.subject, c.env);
-        const data: any = await c.req.json();
-        const body: string = JSON.stringify(data);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "PUT",
-            body: body
-        });
-            logCollector.add({ status: resp.status });
-        if (resp.status == 202) {
-            logCollector.addMessage(`Successfully used secure-subject-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else if (resp.status == 409) {
-            logCollector.addMessage(`Conflict reported on secure-subject-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else {
-            logCollector.addMessage(`Failed to use secure-subject-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage(`Unauthorised to use createSubject.`);
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.subject,
+		method: "PUT",
+		body,
+		successStatuses: [202],
+		forwardStatuses: [409],
+		logName: "secure-subject-endpoint"
+	});
 }

--- a/src/deleteEpisode.ts
+++ b/src/deleteEpisode.ts
@@ -1,88 +1,33 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { LogCollector } from "./LogCollector";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function deleteEpisode(c: Auth0ActionContext): Promise<Response> {
-	const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-	const logCollector = new LogCollector();
-	logCollector.collectRequest(c);
-	const id = c.req.param('id');
+	const id = c.req.param("id");
 	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS", "DELETE"] });
-	if (auth0Payload?.permissions && auth0Payload.permissions.includes('admin')) {
-		const url = new URL(`${getEndpoint(Endpoint.episode, c.env)}/${id}`);
-		const resp = await fetch(url, {
-			headers: buildFetchHeaders(c.req, url),
-			method: "DELETE"
-		});
-		logCollector.add({ status: resp.status });
-		if (resp.status == 200) {
-			logCollector.addMessage(`Successfully used secure-episode-endpoint.`);
-			console.log(logCollector.toEndpointLog());
-			return c.newResponse(resp.body);
-		} else if (resp.status == 404) {
-			logCollector.addMessage(`Failed to use secure-episode-endpoint. Episode not found.`);
-			console.error(logCollector.toEndpointLog());
-			return c.newResponse(resp.body, resp.status);
-		} else if (resp.status == 400) {
-			logCollector.addMessage(`Failed to use secure-episode-endpoint. Episode published.`);
-			console.error(logCollector.toEndpointLog());
-			return c.newResponse(resp.body, resp.status);
-		} else if (resp.status == 300) {
-			logCollector.addMessage(`Failed to use secure-episode-endpoint. Multple podcast/episodes found.`);
-			console.error(logCollector.toEndpointLog());
-			return c.newResponse(resp.body, resp.status);
-		} else {
-			logCollector.addMessage(`Failed to use secure-episode-endpoint..`);
-			console.error(logCollector.toEndpointLog());
-			return c.json({ error: "Error" }, 500);
-		}
-	}
-	logCollector.addMessage("Unauthorised to use deleteEpisode.");
-	console.error(logCollector.toEndpointLog());
-	return c.json({ error: "Unauthorised" }, 403);
+	return proxyToAzure(c, {
+		permission: "admin",
+		endpoint: Endpoint.episode,
+		method: "DELETE",
+		pathSuffix: `/${encodeURIComponent(id)}`,
+		successStatuses: [200],
+		forwardStatuses: [404, 400, 300],
+		logName: "secure-episode-endpoint"
+	});
 }
 
 export async function deletePodcastEpisode(c: Auth0ActionContext): Promise<Response> {
-	const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-	const logCollector = new LogCollector();
-	logCollector.collectRequest(c);
-	const podcastId = c.req.param('podcastId');
-	const episodeId = c.req.param('episodeId');
+	const podcastId = c.req.param("podcastId");
+	const episodeId = c.req.param("episodeId");
 	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS", "DELETE"] });
-	if (auth0Payload?.permissions && auth0Payload.permissions.includes('admin')) {
-		const url = new URL(`${getEndpoint(Endpoint.episode, c.env)}/${podcastId}/${episodeId}`);
-		const resp = await fetch(url, {
-			headers: buildFetchHeaders(c.req, url),
-			method: "DELETE"
-		});
-		logCollector.add({ status: resp.status });
-		if (resp.status == 200) {
-			logCollector.addMessage(`Successfully used secure-episode-endpoint.`);
-			console.log(logCollector.toEndpointLog());
-			return c.newResponse(resp.body);
-		} else if (resp.status == 404) {
-			logCollector.addMessage(`Failed to use secure-episode-endpoint. Episode not found.`);
-			console.error(logCollector.toEndpointLog());
-			return c.newResponse(resp.body, resp.status);
-		} else if (resp.status == 400) {
-			logCollector.addMessage(`Failed to use secure-episode-endpoint. Episode published.`);
-			console.error(logCollector.toEndpointLog());
-			return c.newResponse(resp.body, resp.status);
-		} else if (resp.status == 300) {
-			logCollector.addMessage(`Failed to use secure-episode-endpoint. Multple podcast/episodes found.`);
-			console.error(logCollector.toEndpointLog());
-			return c.newResponse(resp.body, resp.status);
-		} else {
-			logCollector.addMessage(`Failed to use secure-episode-endpoint..`);
-			console.error(logCollector.toEndpointLog());
-			return c.json({ error: "Error" }, 500);
-		}
-	}
-	logCollector.addMessage("Unauthorised to use deleteEpisode.");
-	console.error(logCollector.toEndpointLog());
-	return c.json({ error: "Unauthorised" }, 403);
+	return proxyToAzure(c, {
+		permission: "admin",
+		endpoint: Endpoint.episode,
+		method: "DELETE",
+		pathSuffix: `/${encodeURIComponent(podcastId)}/${encodeURIComponent(episodeId)}`,
+		successStatuses: [200],
+		forwardStatuses: [404, 400, 300],
+		logName: "secure-episode-endpoint"
+	});
 }

--- a/src/discoverySchedule.ts
+++ b/src/discoverySchedule.ts
@@ -1,75 +1,31 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { LogCollector } from "./LogCollector";
-import { StatusCode } from "hono/utils/http-status";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function getDiscoverySchedule(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, { methods: ["GET", "PUT", "OPTIONS"] });
-    try {
-        if (auth0Payload?.permissions && auth0Payload.permissions.includes('admin')) {
-            const url = getEndpoint(Endpoint.discoverySchedule, c.env);
-            const resp = await fetch(url, {
-                headers: buildFetchHeaders(c.req, url),
-                method: "GET"
-            });
-            logCollector.add({ status: resp.status });
-            if (resp.status == 200) {
-                logCollector.addMessage(`Successfully used discovery-schedule GET.`);
-                console.log(logCollector.toEndpointLog());
-                return c.newResponse(resp.body);
-            }
-            logCollector.addMessage(`Failed discovery-schedule GET.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status as StatusCode);
-        }
-    } catch {
-        logCollector.addMessage("Error in getDiscoverySchedule.");
-        console.error(logCollector.toEndpointLog());
-        return c.json({ error: "An error occurred" }, 500);
-    }
-    logCollector.addMessage("Unauthorised to use getDiscoverySchedule.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, { methods: ["GET", "PUT", "OPTIONS"] });
+	return proxyToAzure(c, {
+		permission: "admin",
+		endpoint: Endpoint.discoverySchedule,
+		method: "GET",
+		successStatuses: [200],
+		passthroughOtherStatuses: true,
+		logName: "discovery-schedule-get"
+	});
 }
 
 export async function putDiscoverySchedule(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, { methods: ["GET", "PUT", "OPTIONS"] });
-    const data: any = await c.req.json();
-    const body: string = JSON.stringify(data);
-    try {
-        if (auth0Payload?.permissions && auth0Payload.permissions.includes('admin')) {
-            const url = getEndpoint(Endpoint.discoverySchedule, c.env);
-            const resp = await fetch(url, {
-                headers: buildFetchHeaders(c.req, url),
-                method: "PUT",
-                body
-            });
-            logCollector.add({ status: resp.status });
-            if (resp.status == 200) {
-                logCollector.addMessage(`Successfully used discovery-schedule PUT.`);
-                console.log(logCollector.toEndpointLog());
-                return c.newResponse(resp.body);
-            }
-            logCollector.addMessage(`Failed discovery-schedule PUT.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status as StatusCode);
-        }
-    } catch {
-        logCollector.addMessage("Error in putDiscoverySchedule.");
-        console.error(logCollector.toEndpointLog());
-        return c.json({ error: "An error occurred" }, 500);
-    }
-    logCollector.addMessage("Unauthorised to use putDiscoverySchedule.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, { methods: ["GET", "PUT", "OPTIONS"] });
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "admin",
+		endpoint: Endpoint.discoverySchedule,
+		method: "PUT",
+		body,
+		successStatuses: [200],
+		passthroughOtherStatuses: true,
+		logName: "discovery-schedule-put"
+	});
 }

--- a/src/getDiscoveryInfo.ts
+++ b/src/getDiscoveryInfo.ts
@@ -36,9 +36,13 @@ export async function getDiscoveryInfo(c: Auth0ActionContext): Promise<Response>
             });
             await stream.pipe(object.body);
         });
-    } else {
+    } else if (!auth0Payload) {
         logCollector.addMessage("Unauthorised to use getDiscoveryInfo.");
         console.error(logCollector.toEndpointLog());
-        return c.json({ message: "Unauthorised" }, 401);
+        return c.json({ error: "Unauthorised" }, 401);
+    } else {
+        logCollector.addMessage("Forbidden to use getDiscoveryInfo.");
+        console.error(logCollector.toEndpointLog());
+        return c.json({ error: "Forbidden" }, 403);
     }
 }

--- a/src/getDiscoveryReports.ts
+++ b/src/getDiscoveryReports.ts
@@ -1,41 +1,20 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function getDiscoveryReports(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, {
-        omitCacheControlHeader: true,
-        methods: ["POST", "GET", "OPTIONS"]
-    });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        let url = getEndpoint(Endpoint.discoveryCuration, c.env);
-        const reqUrl = new URL(c.req.url);
-        if (reqUrl.search) {
-            url = new URL(url.toString() + reqUrl.search);
-        }
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "GET"
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure secure-discovery-curation-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else {
-            logCollector.addMessage(`Failed to use secure-discovery-curation-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use getDiscoveryReports.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, {
+		omitCacheControlHeader: true,
+		methods: ["POST", "GET", "OPTIONS"]
+	});
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.discoveryCuration,
+		method: "GET",
+		appendRequestSearch: true,
+		successStatuses: [200],
+		forwardStatuses: [400, 401, 403, 404],
+		logName: "secure-discovery-curation-endpoint"
+	});
 }

--- a/src/getEpisode.ts
+++ b/src/getEpisode.ts
@@ -1,79 +1,39 @@
-import { AddResponseHeaders } from './AddResponseHeaders';
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
+import { AddResponseHeaders } from "./AddResponseHeaders";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from './buildFetchHeaders';
-import { LogCollector } from './LogCollector';
-import { getEndpoint } from './endpoints';
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function getEpisode(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    const id = c.req.param('id');
-    AddResponseHeaders(c, {
-        omitCacheControlHeader: true,
-        methods: ["POST", "GET", "OPTIONS", "DELETE"]
-    });
-
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        const url = new URL(`${getEndpoint(Endpoint.episode, c.env)}/${id}`);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "GET"
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-episode-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else if (resp.status == 404) {
-            logCollector.addMessage(`Successfully used secure-episode-endpoint. Episode not found.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else {
-            logCollector.addMessage(`Failed to use secure-episode-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use getEpisode.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	const id = c.req.param("id");
+	AddResponseHeaders(c, {
+		omitCacheControlHeader: true,
+		methods: ["POST", "GET", "OPTIONS", "DELETE"]
+	});
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.episode,
+		method: "GET",
+		pathSuffix: `/${encodeURIComponent(id)}`,
+		successStatuses: [200],
+		forwardStatuses: [404],
+		logName: "secure-episode-endpoint"
+	});
 }
 
-export async function getPodcastEpisode(c:Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    const podcastName = c.req.param('podcastName');
-    const episodeId = c.req.param('episodeId');
-    AddResponseHeaders(c, {
-        omitCacheControlHeader: true,
-        methods: ["POST", "GET", "OPTIONS", "DELETE"]
-    });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        const url = new URL(`${getEndpoint(Endpoint.episode, c.env)}/${podcastName}/${episodeId}`);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "GET"
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-episode-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else if (resp.status == 404) {
-            logCollector.addMessage(`Successfully used secure-episode-endpoint. Episode not found.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else {
-            logCollector.addMessage(`Failed to use secure-episode-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use getEpisode.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+export async function getPodcastEpisode(c: Auth0ActionContext): Promise<Response> {
+	const podcastName = c.req.param("podcastName");
+	const episodeId = c.req.param("episodeId");
+	AddResponseHeaders(c, {
+		omitCacheControlHeader: true,
+		methods: ["POST", "GET", "OPTIONS", "DELETE"]
+	});
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.episode,
+		method: "GET",
+		pathSuffix: `/${encodeURIComponent(podcastName)}/${encodeURIComponent(episodeId)}`,
+		successStatuses: [200],
+		forwardStatuses: [404],
+		logName: "secure-episode-endpoint"
+	});
 }

--- a/src/getFlairs.ts
+++ b/src/getFlairs.ts
@@ -30,9 +30,13 @@ export async function getFlairs(c: Auth0ActionContext): Promise<Response> {
             });
             await stream.pipe(object.body);
         });
-    } else {
+    } else if (!auth0Payload) {
         logCollector.addMessage("Unauthorised to use getFlairs.");
         console.error(logCollector.toEndpointLog());
-        return c.json({ message: "Unauthorised" }, 401);
+        return c.json({ error: "Unauthorised" }, 401);
+    } else {
+        logCollector.addMessage("Forbidden to use getFlairs.");
+        console.error(logCollector.toEndpointLog());
+        return c.json({ error: "Forbidden" }, 403);
     }
 }

--- a/src/getLanguages.ts
+++ b/src/getLanguages.ts
@@ -30,9 +30,13 @@ export async function getLanguages(c: Auth0ActionContext): Promise<Response> {
 			});
 			await stream.pipe(object.body);
 		});
-	} else {
+	} else if (!auth0Payload) {
 		logCollector.addMessage("Unauthorised to use getLanguages.");
 		console.error(logCollector.toEndpointLog());
-		return c.json({ message: "Unauthorised" }, 401);
+		return c.json({ error: "Unauthorised" }, 401);
+	} else {
+		logCollector.addMessage("Forbidden to use getLanguages.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Forbidden" }, 403);
 	}
 }

--- a/src/getOutgoing.ts
+++ b/src/getOutgoing.ts
@@ -1,44 +1,20 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function getOutgoing(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, {
-        omitCacheControlHeader: true,
-        methods: ["POST", "GET", "OPTIONS"]
-    });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        let url = getEndpoint(Endpoint.outgoingEpisodes, c.env);
-        const reqUrl = new URL(c.req.url);
-        if (reqUrl.search) {
-            url = new URL(url.toString() + reqUrl.search);
-        }
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "GET"
-        });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-episodes-outgoing-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else if (resp.status == 400) {
-            logCollector.addMessage(`Bad request to use secure-episodes-outgoing-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, 400);
-        } else {
-            logCollector.addMessage(`Failed to use secure-episodes-outgoing-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use getOutgoing.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, {
+		omitCacheControlHeader: true,
+		methods: ["POST", "GET", "OPTIONS"]
+	});
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.outgoingEpisodes,
+		method: "GET",
+		appendRequestSearch: true,
+		successStatuses: [200],
+		forwardStatuses: [400],
+		logName: "secure-episodes-outgoing-endpoint"
+	});
 }

--- a/src/getPeople.ts
+++ b/src/getPeople.ts
@@ -104,13 +104,21 @@ export async function getPeople(c: Auth0ActionContext): Promise<Response> {
 
 		return c.notFound();
 
-	} else {
+	} else if (!auth0Payload) {
 
 		logCollector.addMessage("Unauthorised to use getPeople.");
 
 		console.error(logCollector.toEndpointLog());
 
-		return c.json({ message: "Unauthorised" }, 401);
+		return c.json({ error: "Unauthorised" }, 401);
+
+	} else {
+
+		logCollector.addMessage("Forbidden to use getPeople.");
+
+		console.error(logCollector.toEndpointLog());
+
+		return c.json({ error: "Forbidden" }, 403);
 
 	}
 

--- a/src/getPersonByName.ts
+++ b/src/getPersonByName.ts
@@ -1,43 +1,21 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { encodeUrlParameter } from "./encodeUrlParameter";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function getPersonByName(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    const name = c.req.param('name');
-    AddResponseHeaders(c, {
-        omitCacheControlHeader: true,
-        methods: ["POST", "GET", "OPTIONS"]
-    });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        const url = new URL(`${getEndpoint(Endpoint.person, c.env)}/${encodeUrlParameter(name)}`);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "GET"
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-person-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else if (resp.status == 404) {
-            logCollector.addMessage(`Person not found on secure-person-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Not found" }, 404);
-        } else {
-            logCollector.addMessage(`Failed to use secure-person-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use getPersonByName.");
-    console.log(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	const name = c.req.param("name");
+	AddResponseHeaders(c, {
+		omitCacheControlHeader: true,
+		methods: ["POST", "GET", "OPTIONS"]
+	});
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.person,
+		method: "GET",
+		pathSuffix: `/${encodeURIComponent(name)}`,
+		successStatuses: [200],
+		forwardStatuses: [404],
+		logName: "secure-person-endpoint"
+	});
 }

--- a/src/getPodcastByName.ts
+++ b/src/getPodcastByName.ts
@@ -1,47 +1,21 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { encodeUrlParameter } from "./encodeUrlParameter";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function getPodcastByName(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    const name = c.req.param('name');
-    AddResponseHeaders(c, {
-        omitCacheControlHeader: true,
-        methods: ["POST", "GET", "OPTIONS"]
-    });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        const url = new URL(`${getEndpoint(Endpoint.podcast, c.env)}/${encodeUrlParameter(name)}`);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "GET"
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-podcast-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else if (resp.status == 404) {
-            logCollector.addMessage(`Unable to find podcast.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else if (resp.status == 409) {
-            logCollector.addMessage(`Multiple podcasts found.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else {
-            logCollector.addMessage(`Failed to use secure-podcast-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use getPodcastByName.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	const name = c.req.param("name");
+	AddResponseHeaders(c, {
+		omitCacheControlHeader: true,
+		methods: ["POST", "GET", "OPTIONS"]
+	});
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.podcast,
+		method: "GET",
+		pathSuffix: `/${encodeURIComponent(name)}`,
+		successStatuses: [200],
+		forwardStatuses: [404, 409],
+		logName: "secure-podcast-endpoint"
+	});
 }

--- a/src/getPodcastByNameAndEpisodeId.ts
+++ b/src/getPodcastByNameAndEpisodeId.ts
@@ -1,48 +1,22 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { encodeUrlParameter } from "./encodeUrlParameter";
 import { Endpoint } from "./Endpoint";
-import { getEndpoint } from "./endpoints";
-import { LogCollector } from "./LogCollector";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function getPodcastByNameAndEpisodeId(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    const name = c.req.param('name');
-    const id = c.req.param('id');
-    AddResponseHeaders(c, {
-        omitCacheControlHeader: true,
-        methods: ["POST", "GET", "OPTIONS"]
-    });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        const url = new URL(`${getEndpoint(Endpoint.podcast, c.env)}/${encodeUrlParameter(name)}/${encodeUrlParameter(id)}`);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "GET"
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-podcast-endpoint with episode-id.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else if (resp.status == 404) {
-            logCollector.addMessage(`Unable to find podcast with episode-id.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else if (resp.status == 409) {
-            logCollector.addMessage(`Multiple podcasts found with episode-id.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else {
-            logCollector.addMessage(`Failed to use secure-podcast-endpoint with episode-id.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use getPodcastByName with episode-id.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	const name = c.req.param("name");
+	const id = c.req.param("id");
+	AddResponseHeaders(c, {
+		omitCacheControlHeader: true,
+		methods: ["POST", "GET", "OPTIONS"]
+	});
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.podcast,
+		method: "GET",
+		pathSuffix: `/${encodeURIComponent(name)}/${encodeURIComponent(id)}`,
+		successStatuses: [200],
+		forwardStatuses: [404, 409],
+		logName: "secure-podcast-endpoint-with-episode-id"
+	});
 }

--- a/src/getSubjectByName.ts
+++ b/src/getSubjectByName.ts
@@ -1,40 +1,20 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { encodeUrlParameter } from "./encodeUrlParameter";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function getSubjectByName(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    const name = c.req.param('name');
-    AddResponseHeaders(c, {
-        omitCacheControlHeader: true,
-        methods: ["POST", "GET", "OPTIONS"]
-    });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        const url = new URL(`${getEndpoint(Endpoint.subject, c.env)}/${encodeUrlParameter(name)}`);
-        console.log("getSubjectByName: " + url);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "GET"
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-subject-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else {
-            logCollector.addMessage(`Failed to use secure-subject-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use getSubjectByName.");
-    console.log(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	const name = c.req.param("name");
+	AddResponseHeaders(c, {
+		omitCacheControlHeader: true,
+		methods: ["POST", "GET", "OPTIONS"]
+	});
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.subject,
+		method: "GET",
+		pathSuffix: `/${encodeURIComponent(name)}`,
+		successStatuses: [200],
+		logName: "secure-subject-endpoint"
+	});
 }

--- a/src/getSubjects.ts
+++ b/src/getSubjects.ts
@@ -30,9 +30,13 @@ export async function getSubjects(c: Auth0ActionContext): Promise<Response> {
 			});
 			await stream.pipe(object.body);
 		});
-	} else {
+	} else if (!auth0Payload) {
 		logCollector.addMessage("Unauthorised to use getSubjects.");
 		console.error(logCollector.toEndpointLog());
-		return c.json({ message: "Unauthorised" }, 401);
+		return c.json({ error: "Unauthorised" }, 401);
+	} else {
+		logCollector.addMessage("Forbidden to use getSubjects.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Forbidden" }, 403);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,7 @@ const requireOpenApiAuth = async (c: any, next: () => Promise<void>) => {
 		if (pathname.startsWith('/docs')) {
 			return c.redirect('/docs/login');
 		}
-		return c.json({ error: 'Unauthorised' }, 403);
+		return c.json({ error: 'Unauthorised' }, 401);
 	}
 	if (!isAdmin(payload)) {
 		return c.json({ error: 'Forbidden' }, 403);
@@ -199,10 +199,13 @@ app.get('/docs/auth/callback', async (c) => {
 	const stateCookie = getCookie(c, OPENAPI_AUTH_STATE_COOKIE);
 
 	if (!state || !stateCookie || state !== stateCookie) {
-		return c.json({ error: 'Invalid auth state' }, 403);
+		return c.json({ error: 'Invalid auth state' }, 401);
 	}
 
 	const payload = await tryGetPayload(c, token);
+	if (!payload) {
+		return c.json({ error: 'Unauthorised' }, 401);
+	}
 	if (!isAdmin(payload)) {
 		return c.json({ error: 'Forbidden' }, 403);
 	}

--- a/src/indexPodcastByName.ts
+++ b/src/indexPodcastByName.ts
@@ -1,48 +1,21 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { encodeUrlParameter } from "./encodeUrlParameter";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function indexPodcastByName(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    const name = c.req.param('name');
-    AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        const url = new URL(`${getEndpoint(Endpoint.podcastIndex, c.env)}/${encodeUrlParameter(name)}`);
-        console.log("indexPodcastByName: " + url);
-        const data: any = await c.req.json();
-        const body: string = JSON.stringify(data);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "POST",
-            body: body
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-podcast-index-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else if (resp.status == 404) {
-            logCollector.addMessage(`Successfully used secure-podcast-index-endpoint. Not Found.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else if (resp.status == 400) {
-            logCollector.addMessage(`Successfully used secure-podcast-index-endpoint. Not Performed.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else {
-            logCollector.addMessage(`Failed to use secure-podcast-index-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use indexPodcastByName.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	const name = c.req.param("name");
+	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.podcastIndex,
+		method: "POST",
+		pathSuffix: `/${encodeURIComponent(name)}`,
+		body,
+		successStatuses: [200],
+		forwardStatuses: [404, 400],
+		logName: "secure-podcast-index-endpoint"
+	});
 }

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -24,12 +24,16 @@ import { homepage } from "./homepage";
 import { homepageSsr } from "./homepageSsr";
 import { indexPodcastByName } from "./indexPodcastByName";
 import {
+	bookmarksListResponseSchema,
+	discoveryCurationResponseSchema,
 	discoveryScheduleResponseSchema,
 	discoveryScheduleUpdateRequestSchema,
 	discoverySubmitRequestSchema,
 	episodeChangeRequestSchema,
 	errorSchema,
+	flairsResponseSchema,
 	jsonBody,
+	languagesResponseSchema,
 	opaqueJsonSchema,
 	opaqueObjectRequestSchema,
 	personChangeRequestSchema,
@@ -180,7 +184,7 @@ export const GetFlairsRoute = createOpenApiRoute(getFlairs, {
     schema: {
         tags: ["Subjects"],
         summary: "List flairs",
-        responses: { 200: { description: "Flairs", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: { 200: { description: "Flairs", ...contentJson(flairsResponseSchema) }, ...authResponses }
     }
 });
 
@@ -367,7 +371,7 @@ export const GetDiscoveryReportsRoute = createOpenApiRoute(getDiscoveryReports, 
     schema: {
         tags: ["Discovery"],
         summary: "Get discovery curation reports",
-        responses: { 200: { description: "Discovery reports", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: { 200: { description: "Discovery reports", ...contentJson(discoveryCurationResponseSchema) }, ...authResponses }
     }
 });
 
@@ -492,7 +496,7 @@ export const GetBookmarksRoute = createOpenApiRoute(getBookmarks, {
     schema: {
         tags: ["Bookmarks"],
         summary: "List current user bookmarks",
-        responses: { 200: { description: "Bookmarks", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: { 200: { description: "Bookmarks", ...contentJson(bookmarksListResponseSchema) }, ...authResponses }
     }
 });
 
@@ -511,6 +515,6 @@ export const GetLanguagesRoute = createOpenApiRoute(getLanguages, {
     schema: {
         tags: ["Metadata"],
         summary: "List languages",
-        responses: { 200: { description: "Languages", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: { 200: { description: "Languages", ...contentJson(languagesResponseSchema) }, ...authResponses }
     }
 });

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -29,20 +29,36 @@ import {
 	discoveryScheduleResponseSchema,
 	discoveryScheduleUpdateRequestSchema,
 	discoverySubmitRequestSchema,
+	discoverySubmitResponseSchema,
 	episodeChangeRequestSchema,
+	episodeDeleteBlockedSchema,
+	episodeDtoSchema,
+	episodeListResponseSchema,
+	episodePublishResponseSchema,
+	episodeUpdateResponseSchema,
 	errorSchema,
 	flairsResponseSchema,
+	indexPodcastResponseSchema,
+	indexerStateDtoSchema,
 	jsonBody,
 	languagesResponseSchema,
 	opaqueJsonSchema,
 	opaqueObjectRequestSchema,
+	peopleListResponseSchema,
 	personChangeRequestSchema,
+	personDtoSchema,
 	podcastChangeRequestSchema,
+	podcastDtoSchema,
 	podcastRenameRequestSchema,
+	podcastRenameResponseSchema,
+	publicEpisodeDtoSchema,
+	publishHomepageResponseSchema,
 	pushSubscriptionRequestSchema,
 	searchRequestSchema,
 	subjectChangeRequestSchema,
+	subjectDtoSchema,
 	submitUrlRequestSchema,
+	submitUrlResponseSchema,
 	termSubmitRequestSchema
 } from "./openapiSchemas";
 import { publicGetEpisode } from "./publicGetEpisode";
@@ -86,7 +102,7 @@ function createOpenApiRoute(handler: RouteHandler, options: RouteFactoryOptions 
     };
 }
 
-/** Opaque success JSON until response DTOs are modelled per route. */
+/** Opaque success JSON until response DTOs are modelled per route (search, R2 subjects, page details). */
 const genericOkSchema = opaqueJsonSchema;
 
 /**
@@ -94,8 +110,7 @@ const genericOkSchema = opaqueJsonSchema;
  * - 401 Unauthorized: missing or invalid bearer / Auth0 payload
  * - 403 Forbidden: authenticated but missing required permission (e.g. curate, admin)
  *
- * Note: many Azure proxy handlers still collapse both cases to 403 until Wave 3
- * `proxyToAzure` extract; R2 list handlers + OpenAPI docs gate follow this matrix.
+ * Proxied Azure routes also surface upstream 4xx via forwardStatuses / passthrough.
  */
 const authResponses = {
     401: {
@@ -104,6 +119,20 @@ const authResponses = {
     },
     403: {
         description: "Forbidden — authenticated but missing required permission",
+        ...contentJson(errorSchema)
+    }
+};
+
+const notFoundResponse = {
+    404: {
+        description: "Not found",
+        ...contentJson(errorSchema)
+    }
+};
+
+const serverErrorResponse = {
+    500: {
+        description: "Upstream or worker failure",
         ...contentJson(errorSchema)
     }
 };
@@ -136,7 +165,7 @@ export const GetSubjectsRoute = createOpenApiRoute(getSubjects, {
     schema: {
         tags: ["Subjects"],
         summary: "List subjects",
-        responses: { 200: { description: "Subjects", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: { 200: { description: "Subjects (R2 JSON)", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
 
@@ -145,7 +174,11 @@ export const GetPeopleRoute = createOpenApiRoute(getPeople, {
     schema: {
         tags: ["People"],
         summary: "List people",
-        responses: { 200: { description: "People", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "People", ...contentJson(peopleListResponseSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -155,7 +188,12 @@ export const GetPersonByNameRoute = createOpenApiRoute(getPersonByName, {
         tags: ["People"],
         summary: "Get person by name",
         request: { params: nameParam },
-        responses: { 200: { description: "Person", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Person", ...contentJson(personDtoSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -165,7 +203,12 @@ export const UpdatePersonRoute = createOpenApiRoute(updatePerson, {
         tags: ["People"],
         summary: "Update person by id",
         request: { params: idParam, body: jsonBody(personChangeRequestSchema) },
-        responses: { 202: { description: "Person updated", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            202: { description: "Person updated (empty body)" },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -175,7 +218,13 @@ export const CreatePersonRoute = createOpenApiRoute(createPerson, {
         tags: ["People"],
         summary: "Create person",
         request: { body: jsonBody(personChangeRequestSchema) },
-        responses: { 202: { description: "Person created", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            202: { description: "Person created", ...contentJson(personDtoSchema) },
+            400: { description: "Validation error", ...contentJson(errorSchema) },
+            409: { description: "Conflict", ...contentJson(errorSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -203,7 +252,12 @@ export const SubmitRoute = createOpenApiRoute(submit, {
         tags: ["Submission"],
         summary: "Submit episode URL",
         request: { body: jsonBody(submitUrlRequestSchema) },
-        responses: { 200: { description: "Submission accepted", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Submission accepted", ...contentJson(submitUrlResponseSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -213,7 +267,12 @@ export const GetEpisodeRoute = createOpenApiRoute(getEpisode, {
         tags: ["Episodes"],
         summary: "Get episode by id",
         request: { params: idParam },
-        responses: { 200: { description: "Episode", ...contentJson(genericOkSchema) }, 404: { description: "Not found" }, ...authResponses }
+        responses: {
+            200: { description: "Episode", ...contentJson(episodeDtoSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -221,9 +280,14 @@ export const GetPodcastEpisodeRoute = createOpenApiRoute(getPodcastEpisode, {
     auth: true,
     schema: {
         tags: ["Episodes"],
-        summary: "Get podcast episode by podcast id and episode id",
+        summary: "Get podcast episode by podcast name and episode id",
         request: { params: podcastAndEpisodeParam },
-        responses: { 200: { description: "Podcast episode", ...contentJson(genericOkSchema) }, 404: { description: "Not found" }, ...authResponses }
+        responses: {
+            200: { description: "Episode", ...contentJson(episodeDtoSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -233,7 +297,12 @@ export const UpdateEpisodeRoute = createOpenApiRoute(updateEpisode, {
         tags: ["Episodes"],
         summary: "Update episode by id",
         request: { params: idParam, body: jsonBody(episodeChangeRequestSchema) },
-        responses: { 200: { description: "Updated", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            202: { description: "Accepted", ...contentJson(episodeUpdateResponseSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -243,7 +312,12 @@ export const UpdatePodcastEpisodeRoute = createOpenApiRoute(updatePodcastEpisode
         tags: ["Episodes"],
         summary: "Update podcast episode by podcast id and episode id",
         request: { params: podcastIdAndEpisodeParam, body: jsonBody(episodeChangeRequestSchema) },
-        responses: { 200: { description: "Updated", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            202: { description: "Accepted", ...contentJson(episodeUpdateResponseSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -253,7 +327,14 @@ export const DeleteEpisodeRoute = createOpenApiRoute(deleteEpisode, {
         tags: ["Episodes"],
         summary: "Delete episode by id",
         request: { params: idParam },
-        responses: { 200: { description: "Deleted", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Deleted (empty body)" },
+            400: { description: "Delete blocked (e.g. already posted)", ...contentJson(episodeDeleteBlockedSchema) },
+            409: { description: "Conflict" },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -263,7 +344,14 @@ export const DeletePodcastEpisodeRoute = createOpenApiRoute(deletePodcastEpisode
         tags: ["Episodes"],
         summary: "Delete podcast episode by podcast id and episode id",
         request: { params: podcastIdAndEpisodeParam },
-        responses: { 200: { description: "Deleted", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Deleted (empty body)" },
+            400: { description: "Delete blocked (e.g. already posted)", ...contentJson(episodeDeleteBlockedSchema) },
+            409: { description: "Conflict" },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -273,7 +361,12 @@ export const PublishPodcastEpisodeRoute = createOpenApiRoute(publishPodcastEpiso
         tags: ["Publishing"],
         summary: "Publish podcast episode by podcast id and episode id",
         request: { params: podcastIdAndEpisodeParam, body: jsonBody(opaqueObjectRequestSchema) },
-        responses: { 200: { description: "Published", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Published", ...contentJson(episodePublishResponseSchema) },
+            400: { description: "Publish outcome with failure details", ...contentJson(episodePublishResponseSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -282,7 +375,11 @@ export const GetOutgoingRoute = createOpenApiRoute(getOutgoing, {
     schema: {
         tags: ["Episodes"],
         summary: "Get outgoing episodes",
-        responses: { 200: { description: "Outgoing episodes", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Outgoing episodes", ...contentJson(episodeListResponseSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -292,7 +389,13 @@ export const GetPodcastByNameRoute = createOpenApiRoute(getPodcastByName, {
         tags: ["Podcasts"],
         summary: "Get podcast by name",
         request: { params: nameParam },
-        responses: { 200: { description: "Podcast", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Podcast", ...contentJson(podcastDtoSchema) },
+            409: { description: "Ambiguous podcast name", ...contentJson(z.array(z.string().uuid())) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -302,7 +405,13 @@ export const GetPodcastByNameAndEpisodeIdRoute = createOpenApiRoute(getPodcastBy
         tags: ["Podcasts"],
         summary: "Get podcast by name and episode id",
         request: { params: podcastNameAndIdParam },
-        responses: { 200: { description: "Podcast episode", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Podcast", ...contentJson(podcastDtoSchema) },
+            409: { description: "Ambiguous podcast name", ...contentJson(z.array(z.string().uuid())) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -312,7 +421,12 @@ export const UpdatePodcastPostRoute = createOpenApiRoute(updatePodcast, {
         tags: ["Podcasts"],
         summary: "Update podcast by id (POST)",
         request: { params: idParam, body: jsonBody(podcastChangeRequestSchema) },
-        responses: { 200: { description: "Podcast updated", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            202: { description: "Accepted (empty or indexing failure fields)" },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -322,7 +436,12 @@ export const UpdatePodcastPutRoute = createOpenApiRoute(updatePodcast, {
         tags: ["Podcasts"],
         summary: "Update podcast by id (PUT)",
         request: { params: idParam, body: jsonBody(podcastChangeRequestSchema) },
-        responses: { 200: { description: "Podcast updated", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            202: { description: "Accepted (empty or indexing failure fields)" },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -332,7 +451,13 @@ export const IndexPodcastByNameRoute = createOpenApiRoute(indexPodcastByName, {
         tags: ["Podcasts"],
         summary: "Reindex podcast by name",
         request: { params: nameParam },
-        responses: { 200: { description: "Indexed", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Indexed", ...contentJson(indexPodcastResponseSchema) },
+            400: { description: "Bad request", ...contentJson(indexPodcastResponseSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -342,7 +467,12 @@ export const GetSubjectByNameRoute = createOpenApiRoute(getSubjectByName, {
         tags: ["Subjects"],
         summary: "Get subject by name",
         request: { params: nameParam },
-        responses: { 200: { description: "Subject", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Subject", ...contentJson(subjectDtoSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -352,7 +482,12 @@ export const UpdateSubjectRoute = createOpenApiRoute(updateSubject, {
         tags: ["Subjects"],
         summary: "Update subject by id",
         request: { params: idParam, body: jsonBody(subjectChangeRequestSchema) },
-        responses: { 200: { description: "Subject updated", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            202: { description: "Accepted (empty body)" },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -362,7 +497,13 @@ export const CreateSubjectRoute = createOpenApiRoute(createSubject, {
         tags: ["Subjects"],
         summary: "Create subject",
         request: { body: jsonBody(subjectChangeRequestSchema) },
-        responses: { 200: { description: "Subject created", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            202: { description: "Subject created", ...contentJson(subjectDtoSchema) },
+            400: { description: "Validation error", ...contentJson(errorSchema) },
+            409: { description: "Conflict", ...contentJson(errorSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -371,7 +512,13 @@ export const GetDiscoveryReportsRoute = createOpenApiRoute(getDiscoveryReports, 
     schema: {
         tags: ["Discovery"],
         summary: "Get discovery curation reports",
-        responses: { 200: { description: "Discovery reports", ...contentJson(discoveryCurationResponseSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Discovery reports", ...contentJson(discoveryCurationResponseSchema) },
+            400: { description: "Bad request", ...contentJson(errorSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -381,7 +528,15 @@ export const SubmitDiscoveryRoute = createOpenApiRoute(submitDiscovery, {
         tags: ["Discovery"],
         summary: "Submit discovery curation",
         request: { body: jsonBody(discoverySubmitRequestSchema) },
-        responses: { 200: { description: "Discovery curation submitted", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Discovery curation submitted", ...contentJson(discoverySubmitResponseSchema) },
+            400: { description: "Bad request", ...contentJson(errorSchema) },
+            409: { description: "Conflict", ...contentJson(errorSchema) },
+            422: { description: "Unprocessable", ...contentJson(errorSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -399,7 +554,12 @@ export const RunSearchIndexerRoute = createOpenApiRoute(runSearchIndexer, {
     schema: {
         tags: ["Admin"],
         summary: "Run search indexer",
-        responses: { 200: { description: "Indexer run response", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Indexer run response", ...contentJson(indexerStateDtoSchema) },
+            400: { description: "Bad request", ...contentJson(indexerStateDtoSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -409,7 +569,11 @@ export const PublishHomepageRoute = createOpenApiRoute(publishHomepage, {
         tags: ["Publishing"],
         summary: "Publish homepage",
         request: { body: jsonBody(opaqueObjectRequestSchema) },
-        responses: { 200: { description: "Homepage published", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Homepage published", ...contentJson(publishHomepageResponseSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -419,7 +583,12 @@ export const PublishTermRoute = createOpenApiRoute(publishTerm, {
         tags: ["Publishing"],
         summary: "Publish term",
         request: { body: jsonBody(termSubmitRequestSchema) },
-        responses: { 200: { description: "Term published", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Term published (empty object)" },
+            409: { description: "Conflict" },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -428,7 +597,11 @@ export const GetDiscoveryScheduleRoute = createOpenApiRoute(getDiscoverySchedule
     schema: {
         tags: ["Discovery"],
         summary: "Get Discovery UK schedule",
-        responses: { 200: { description: "Schedule", ...contentJson(discoveryScheduleResponseSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Schedule", ...contentJson(discoveryScheduleResponseSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -438,7 +611,12 @@ export const PutDiscoveryScheduleRoute = createOpenApiRoute(putDiscoverySchedule
         tags: ["Discovery"],
         summary: "Update Discovery UK schedule",
         request: { body: jsonBody(discoveryScheduleUpdateRequestSchema) },
-        responses: { 200: { description: "Schedule updated", ...contentJson(discoveryScheduleResponseSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Schedule updated", ...contentJson(discoveryScheduleResponseSchema) },
+            400: { description: "Bad request", ...contentJson(errorSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -448,7 +626,14 @@ export const RenamePodcastRoute = createOpenApiRoute(renamePodcast, {
         tags: ["Podcasts"],
         summary: "Rename podcast",
         request: { params: nameParam, body: jsonBody(podcastRenameRequestSchema) },
-        responses: { 200: { description: "Podcast renamed", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Podcast renamed", ...contentJson(podcastRenameResponseSchema) },
+            400: { description: "Bad request" },
+            409: { description: "Conflict" },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -458,7 +643,11 @@ export const PushSubscriptionRoute = createOpenApiRoute(pushSubscription, {
         tags: ["Notifications"],
         summary: "Create push subscription",
         request: { body: jsonBody(pushSubscriptionRequestSchema) },
-        responses: { 200: { description: "Subscription stored", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Subscription stored (empty body)" },
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 
@@ -506,7 +695,12 @@ export const PublicGetEpisodeRoute = createOpenApiRoute(publicGetEpisode, {
         tags: ["Episodes"],
         summary: "Get public episode by id",
         request: { params: idParam },
-        responses: { 200: { description: "Public episode", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Public episode", ...contentJson(publicEpisodeDtoSchema) },
+            ...notFoundResponse,
+            ...serverErrorResponse,
+            ...authResponses
+        }
     }
 });
 

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -41,7 +41,7 @@ import {
 	errorSchema,
 	flairsResponseSchema,
 	homepageResponseSchema,
-	homepageSsrResponseSchema,
+	preProcessedHomepageResponseSchema,
 	indexPodcastResponseSchema,
 	indexerStateDtoSchema,
 	jsonBody,
@@ -161,23 +161,17 @@ export const HomepageRoute = createOpenApiRoute(homepage, {
 export const HomepageSsrRoute = createOpenApiRoute(homepageSsr, {
     schema: {
         tags: ["Public"],
-        summary: "Get homepage server-side rendered HTML",
+        summary: "Get pre-processed homepage JSON",
         description:
-            "Returns the pre-rendered homepage HTML document stored in R2 (`homepage-ssr`), " +
-            "published by the content publisher alongside the JSON homepage payload. " +
-            "Body is `text/html` (not JSON) — use `GET /homepage` for the structured HomePageModel.",
+            "Returns R2 key `homepage-ssr` (ContentOptions.PreProcessedHomepageKey): " +
+            "PreProcessedHomePageModel JSON grouped by day. Despite the path name, this is application/json, not HTML. " +
+            "Use `GET /homepage` for the flat HomePageModel (`recentEpisodes`).",
         responses: {
             200: {
-                description:
-                    "Full HTML document for the public homepage (SSR blob). " +
-                    "Content-Type: text/html. Not a JSON schema — the body is markup.",
-                content: {
-                    "text/html": {
-                        schema: homepageSsrResponseSchema
-                    }
-                }
+                description: "PreProcessedHomePageModel — episodesByDay, totals",
+                ...contentJson(preProcessedHomepageResponseSchema)
             },
-            404: { description: "Homepage SSR object missing from R2" }
+            404: { description: "Pre-processed homepage object missing from R2" }
         }
     }
 });

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -75,9 +75,21 @@ const jsonBodySchema = {
     required: true
 } as const;
 
+/**
+ * Auth response matrix (Wave 2 Vitest: auth-matrix.spec.ts):
+ * - 401 Unauthorized: missing or invalid bearer / Auth0 payload
+ * - 403 Forbidden: authenticated but missing required permission (e.g. curate, admin)
+ *
+ * Note: many Azure proxy handlers still collapse both cases to 403 until Wave 3
+ * `proxyToAzure` extract; R2 list handlers + OpenAPI docs gate follow this matrix.
+ */
 const authResponses = {
+    401: {
+        description: "Unauthorized — missing or invalid authentication",
+        ...contentJson(errorSchema)
+    },
     403: {
-        description: "Unauthorized",
+        description: "Forbidden — authenticated but missing required permission",
         ...contentJson(errorSchema)
     }
 };

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -41,6 +41,8 @@ import {
 	episodeUpdateResponseSchema,
 	errorSchema,
 	flairsResponseSchema,
+	homepageResponseSchema,
+	homepageSsrResponseSchema,
 	indexPodcastResponseSchema,
 	indexerStateDtoSchema,
 	jsonBody,
@@ -150,7 +152,10 @@ export const HomepageRoute = createOpenApiRoute(homepage, {
     schema: {
         tags: ["Public"],
         summary: "Get homepage payload",
-        responses: { 200: { description: "Homepage response" } }
+        responses: {
+            200: { description: "Homepage JSON (R2)", ...contentJson(homepageResponseSchema) },
+            404: { description: "Homepage object missing" }
+        }
     }
 });
 
@@ -158,7 +163,17 @@ export const HomepageSsrRoute = createOpenApiRoute(homepageSsr, {
     schema: {
         tags: ["Public"],
         summary: "Get homepage server-side rendered HTML",
-        responses: { 200: { description: "Homepage SSR response" } }
+        responses: {
+            200: {
+                description: "Pre-rendered homepage HTML (R2)",
+                content: {
+                    "text/html": {
+                        schema: homepageSsrResponseSchema
+                    }
+                }
+            },
+            404: { description: "Homepage SSR object missing" }
+        }
     }
 });
 

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -162,16 +162,22 @@ export const HomepageSsrRoute = createOpenApiRoute(homepageSsr, {
     schema: {
         tags: ["Public"],
         summary: "Get homepage server-side rendered HTML",
+        description:
+            "Returns the pre-rendered homepage HTML document stored in R2 (`homepage-ssr`), " +
+            "published by the content publisher alongside the JSON homepage payload. " +
+            "Body is `text/html` (not JSON) — use `GET /homepage` for the structured HomePageModel.",
         responses: {
             200: {
-                description: "Pre-rendered homepage HTML (R2)",
+                description:
+                    "Full HTML document for the public homepage (SSR blob). " +
+                    "Content-Type: text/html. Not a JSON schema — the body is markup.",
                 content: {
                     "text/html": {
                         schema: homepageSsrResponseSchema
                     }
                 }
             },
-            404: { description: "Homepage SSR object missing" }
+            404: { description: "Homepage SSR object missing from R2" }
         }
     }
 });

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -26,14 +26,17 @@ import { indexPodcastByName } from "./indexPodcastByName";
 import {
 	bookmarksListResponseSchema,
 	discoveryCurationResponseSchema,
+	discoveryInfoResponseSchema,
 	discoveryScheduleResponseSchema,
 	discoveryScheduleUpdateRequestSchema,
 	discoverySubmitRequestSchema,
 	discoverySubmitResponseSchema,
+	emptyObjectSchema,
 	episodeChangeRequestSchema,
 	episodeDeleteBlockedSchema,
 	episodeDtoSchema,
 	episodeListResponseSchema,
+	episodePublishRequestSchema,
 	episodePublishResponseSchema,
 	episodeUpdateResponseSchema,
 	errorSchema,
@@ -42,8 +45,8 @@ import {
 	indexerStateDtoSchema,
 	jsonBody,
 	languagesResponseSchema,
-	opaqueJsonSchema,
-	opaqueObjectRequestSchema,
+	messageResponseSchema,
+	pageDetailsResponseSchema,
 	peopleListResponseSchema,
 	personChangeRequestSchema,
 	personDtoSchema,
@@ -55,8 +58,10 @@ import {
 	publishHomepageResponseSchema,
 	pushSubscriptionRequestSchema,
 	searchRequestSchema,
+	searchResponseSchema,
 	subjectChangeRequestSchema,
 	subjectDtoSchema,
+	subjectsNameListResponseSchema,
 	submitUrlRequestSchema,
 	submitUrlResponseSchema,
 	termSubmitRequestSchema
@@ -101,9 +106,6 @@ function createOpenApiRoute(handler: RouteHandler, options: RouteFactoryOptions 
         }
     };
 }
-
-/** Opaque success JSON until response DTOs are modelled per route (search, R2 subjects, page details). */
-const genericOkSchema = opaqueJsonSchema;
 
 /**
  * Auth response matrix (Wave 2 Vitest: auth-matrix.spec.ts):
@@ -165,7 +167,7 @@ export const GetSubjectsRoute = createOpenApiRoute(getSubjects, {
     schema: {
         tags: ["Subjects"],
         summary: "List subjects",
-        responses: { 200: { description: "Subjects (R2 JSON)", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: { 200: { description: "Subjects (R2 name list)", ...contentJson(subjectsNameListResponseSchema) }, ...authResponses }
     }
 });
 
@@ -242,7 +244,7 @@ export const SearchRoute = createOpenApiRoute(search, {
         tags: ["Search"],
         summary: "Search episodes",
         request: { body: jsonBody(searchRequestSchema) },
-        responses: { 200: { description: "Search results", ...contentJson(genericOkSchema) } }
+        responses: { 200: { description: "Search results", ...contentJson(searchResponseSchema) } }
     }
 });
 
@@ -360,7 +362,7 @@ export const PublishPodcastEpisodeRoute = createOpenApiRoute(publishPodcastEpiso
     schema: {
         tags: ["Publishing"],
         summary: "Publish podcast episode by podcast id and episode id",
-        request: { params: podcastIdAndEpisodeParam, body: jsonBody(opaqueObjectRequestSchema) },
+        request: { params: podcastIdAndEpisodeParam, body: jsonBody(episodePublishRequestSchema) },
         responses: {
             200: { description: "Published", ...contentJson(episodePublishResponseSchema) },
             400: { description: "Publish outcome with failure details", ...contentJson(episodePublishResponseSchema) },
@@ -545,7 +547,7 @@ export const GetDiscoveryInfoRoute = createOpenApiRoute(getDiscoveryInfo, {
     schema: {
         tags: ["Discovery"],
         summary: "Get discovery info",
-        responses: { 200: { description: "Discovery info", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: { 200: { description: "Discovery info", ...contentJson(discoveryInfoResponseSchema) }, ...authResponses }
     }
 });
 
@@ -568,7 +570,7 @@ export const PublishHomepageRoute = createOpenApiRoute(publishHomepage, {
     schema: {
         tags: ["Publishing"],
         summary: "Publish homepage",
-        request: { body: jsonBody(opaqueObjectRequestSchema) },
+        request: { body: jsonBody(emptyObjectSchema) },
         responses: {
             200: { description: "Homepage published", ...contentJson(publishHomepageResponseSchema) },
             ...serverErrorResponse,
@@ -656,7 +658,7 @@ export const GetPageDetailsRoute = createOpenApiRoute(getPageDetails, {
         tags: ["Public"],
         summary: "Get page details by podcast and episode",
         request: { params: podcastAndEpisodeParam },
-        responses: { 200: { description: "Page details", ...contentJson(genericOkSchema) } }
+        responses: { 200: { description: "Page details", ...contentJson(pageDetailsResponseSchema) } }
     }
 });
 
@@ -666,7 +668,12 @@ export const AddBookmarkRoute = createOpenApiRoute(addBookmark, {
         tags: ["Bookmarks"],
         summary: "Add bookmark by episode id",
         request: { params: episodeIdParam },
-        responses: { 200: { description: "Bookmark added", ...contentJson(genericOkSchema) }, 409: { description: "Duplicate bookmark" }, ...authResponses }
+        responses: {
+            200: { description: "Bookmark added", ...contentJson(messageResponseSchema) },
+            400: { description: "Unable to create", ...contentJson(messageResponseSchema) },
+            409: { description: "Duplicate bookmark", ...contentJson(messageResponseSchema) },
+            ...authResponses
+        }
     }
 });
 
@@ -676,7 +683,11 @@ export const DeleteBookmarkRoute = createOpenApiRoute(deleteBookmark, {
         tags: ["Bookmarks"],
         summary: "Delete bookmark by episode id",
         request: { params: episodeIdParam },
-        responses: { 200: { description: "Bookmark deleted", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: {
+            200: { description: "Bookmark deleted", ...contentJson(messageResponseSchema) },
+            400: { description: "Unable to delete", ...contentJson(messageResponseSchema) },
+            ...authResponses
+        }
     }
 });
 

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -31,7 +31,6 @@ import {
 	discoveryScheduleUpdateRequestSchema,
 	discoverySubmitRequestSchema,
 	discoverySubmitResponseSchema,
-	emptyObjectSchema,
 	episodeChangeRequestSchema,
 	episodeDeleteBlockedSchema,
 	episodeDtoSchema,
@@ -585,7 +584,7 @@ export const PublishHomepageRoute = createOpenApiRoute(publishHomepage, {
     schema: {
         tags: ["Publishing"],
         summary: "Publish homepage",
-        request: { body: jsonBody(emptyObjectSchema) },
+        // No request body — worker posts "{}" to Azure; PublishController has no [FromBody].
         responses: {
             200: { description: "Homepage published", ...contentJson(publishHomepageResponseSchema) },
             ...serverErrorResponse,

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -23,6 +23,24 @@ import { getSubjects } from "./getSubjects";
 import { homepage } from "./homepage";
 import { homepageSsr } from "./homepageSsr";
 import { indexPodcastByName } from "./indexPodcastByName";
+import {
+	discoveryScheduleResponseSchema,
+	discoveryScheduleUpdateRequestSchema,
+	discoverySubmitRequestSchema,
+	episodeChangeRequestSchema,
+	errorSchema,
+	jsonBody,
+	opaqueJsonSchema,
+	opaqueObjectRequestSchema,
+	personChangeRequestSchema,
+	podcastChangeRequestSchema,
+	podcastRenameRequestSchema,
+	pushSubscriptionRequestSchema,
+	searchRequestSchema,
+	subjectChangeRequestSchema,
+	submitUrlRequestSchema,
+	termSubmitRequestSchema
+} from "./openapiSchemas";
 import { publicGetEpisode } from "./publicGetEpisode";
 import { publishPodcastEpisode } from "./publish";
 import { publishHomepage } from "./publishHomepage";
@@ -64,16 +82,8 @@ function createOpenApiRoute(handler: RouteHandler, options: RouteFactoryOptions 
     };
 }
 
-const errorSchema = z.object({ error: z.string().optional(), message: z.string().optional() });
-const genericOkSchema = z.any();
-const jsonBodySchema = {
-    content: {
-        "application/json": {
-            schema: z.any()
-        }
-    },
-    required: true
-} as const;
+/** Opaque success JSON until response DTOs are modelled per route. */
+const genericOkSchema = opaqueJsonSchema;
 
 /**
  * Auth response matrix (Wave 2 Vitest: auth-matrix.spec.ts):
@@ -150,7 +160,7 @@ export const UpdatePersonRoute = createOpenApiRoute(updatePerson, {
     schema: {
         tags: ["People"],
         summary: "Update person by id",
-        request: { params: idParam, body: jsonBodySchema },
+        request: { params: idParam, body: jsonBody(personChangeRequestSchema) },
         responses: { 202: { description: "Person updated", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -160,7 +170,7 @@ export const CreatePersonRoute = createOpenApiRoute(createPerson, {
     schema: {
         tags: ["People"],
         summary: "Create person",
-        request: { body: jsonBodySchema },
+        request: { body: jsonBody(personChangeRequestSchema) },
         responses: { 202: { description: "Person created", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -178,7 +188,7 @@ export const SearchRoute = createOpenApiRoute(search, {
     schema: {
         tags: ["Search"],
         summary: "Search episodes",
-        request: { body: jsonBodySchema },
+        request: { body: jsonBody(searchRequestSchema) },
         responses: { 200: { description: "Search results", ...contentJson(genericOkSchema) } }
     }
 });
@@ -188,7 +198,7 @@ export const SubmitRoute = createOpenApiRoute(submit, {
     schema: {
         tags: ["Submission"],
         summary: "Submit episode URL",
-        request: { body: jsonBodySchema },
+        request: { body: jsonBody(submitUrlRequestSchema) },
         responses: { 200: { description: "Submission accepted", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -218,7 +228,7 @@ export const UpdateEpisodeRoute = createOpenApiRoute(updateEpisode, {
     schema: {
         tags: ["Episodes"],
         summary: "Update episode by id",
-        request: { params: idParam, body: jsonBodySchema },
+        request: { params: idParam, body: jsonBody(episodeChangeRequestSchema) },
         responses: { 200: { description: "Updated", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -228,7 +238,7 @@ export const UpdatePodcastEpisodeRoute = createOpenApiRoute(updatePodcastEpisode
     schema: {
         tags: ["Episodes"],
         summary: "Update podcast episode by podcast id and episode id",
-        request: { params: podcastIdAndEpisodeParam, body: jsonBodySchema },
+        request: { params: podcastIdAndEpisodeParam, body: jsonBody(episodeChangeRequestSchema) },
         responses: { 200: { description: "Updated", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -258,7 +268,7 @@ export const PublishPodcastEpisodeRoute = createOpenApiRoute(publishPodcastEpiso
     schema: {
         tags: ["Publishing"],
         summary: "Publish podcast episode by podcast id and episode id",
-        request: { params: podcastIdAndEpisodeParam, body: jsonBodySchema },
+        request: { params: podcastIdAndEpisodeParam, body: jsonBody(opaqueObjectRequestSchema) },
         responses: { 200: { description: "Published", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -297,7 +307,7 @@ export const UpdatePodcastPostRoute = createOpenApiRoute(updatePodcast, {
     schema: {
         tags: ["Podcasts"],
         summary: "Update podcast by id (POST)",
-        request: { params: idParam, body: jsonBodySchema },
+        request: { params: idParam, body: jsonBody(podcastChangeRequestSchema) },
         responses: { 200: { description: "Podcast updated", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -307,7 +317,7 @@ export const UpdatePodcastPutRoute = createOpenApiRoute(updatePodcast, {
     schema: {
         tags: ["Podcasts"],
         summary: "Update podcast by id (PUT)",
-        request: { params: idParam, body: jsonBodySchema },
+        request: { params: idParam, body: jsonBody(podcastChangeRequestSchema) },
         responses: { 200: { description: "Podcast updated", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -337,7 +347,7 @@ export const UpdateSubjectRoute = createOpenApiRoute(updateSubject, {
     schema: {
         tags: ["Subjects"],
         summary: "Update subject by id",
-        request: { params: idParam, body: jsonBodySchema },
+        request: { params: idParam, body: jsonBody(subjectChangeRequestSchema) },
         responses: { 200: { description: "Subject updated", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -347,7 +357,7 @@ export const CreateSubjectRoute = createOpenApiRoute(createSubject, {
     schema: {
         tags: ["Subjects"],
         summary: "Create subject",
-        request: { body: jsonBodySchema },
+        request: { body: jsonBody(subjectChangeRequestSchema) },
         responses: { 200: { description: "Subject created", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -366,7 +376,7 @@ export const SubmitDiscoveryRoute = createOpenApiRoute(submitDiscovery, {
     schema: {
         tags: ["Discovery"],
         summary: "Submit discovery curation",
-        request: { body: jsonBodySchema },
+        request: { body: jsonBody(discoverySubmitRequestSchema) },
         responses: { 200: { description: "Discovery curation submitted", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -394,7 +404,7 @@ export const PublishHomepageRoute = createOpenApiRoute(publishHomepage, {
     schema: {
         tags: ["Publishing"],
         summary: "Publish homepage",
-        request: { body: jsonBodySchema },
+        request: { body: jsonBody(opaqueObjectRequestSchema) },
         responses: { 200: { description: "Homepage published", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -404,7 +414,7 @@ export const PublishTermRoute = createOpenApiRoute(publishTerm, {
     schema: {
         tags: ["Publishing"],
         summary: "Publish term",
-        request: { body: jsonBodySchema },
+        request: { body: jsonBody(termSubmitRequestSchema) },
         responses: { 200: { description: "Term published", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -414,7 +424,7 @@ export const GetDiscoveryScheduleRoute = createOpenApiRoute(getDiscoverySchedule
     schema: {
         tags: ["Discovery"],
         summary: "Get Discovery UK schedule",
-        responses: { 200: { description: "Schedule", ...contentJson(genericOkSchema) }, ...authResponses }
+        responses: { 200: { description: "Schedule", ...contentJson(discoveryScheduleResponseSchema) }, ...authResponses }
     }
 });
 
@@ -423,8 +433,8 @@ export const PutDiscoveryScheduleRoute = createOpenApiRoute(putDiscoverySchedule
     schema: {
         tags: ["Discovery"],
         summary: "Update Discovery UK schedule",
-        request: { body: jsonBodySchema },
-        responses: { 200: { description: "Schedule updated", ...contentJson(genericOkSchema) }, ...authResponses }
+        request: { body: jsonBody(discoveryScheduleUpdateRequestSchema) },
+        responses: { 200: { description: "Schedule updated", ...contentJson(discoveryScheduleResponseSchema) }, ...authResponses }
     }
 });
 
@@ -433,7 +443,7 @@ export const RenamePodcastRoute = createOpenApiRoute(renamePodcast, {
     schema: {
         tags: ["Podcasts"],
         summary: "Rename podcast",
-        request: { params: nameParam, body: jsonBodySchema },
+        request: { params: nameParam, body: jsonBody(podcastRenameRequestSchema) },
         responses: { 200: { description: "Podcast renamed", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });
@@ -443,7 +453,7 @@ export const PushSubscriptionRoute = createOpenApiRoute(pushSubscription, {
     schema: {
         tags: ["Notifications"],
         summary: "Create push subscription",
-        request: { body: jsonBodySchema },
+        request: { body: jsonBody(pushSubscriptionRequestSchema) },
         responses: { 200: { description: "Subscription stored", ...contentJson(genericOkSchema) }, ...authResponses }
     }
 });

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -2,20 +2,18 @@ import { z } from "zod";
 
 /**
  * OpenAPI/Zod contracts for the Cloudflare Api worker.
- * Known Azure/DTO shapes are strict objects (no `.passthrough()` / open records) so
- * Swagger examples show real fields instead of additionalProp1/2/3.
- * `opaqueJsonSchema` / `opaqueObjectRequestSchema` remain only for unmodelled blobs.
+ * Known Azure/DTO / R2 / Search shapes are strict objects (no `.passthrough()` /
+ * open records) so Swagger examples show real fields instead of additionalProp1/2/3.
  */
-
-/** Prefer over `z.any()` — documents "some JSON" without claiming a shape. */
-export const opaqueJsonSchema = z.union([
-	z.record(z.string(), z.unknown()),
-	z.array(z.unknown())
-]);
 
 export const errorSchema = z.object({
 	error: z.string().optional(),
 	message: z.string().optional()
+});
+
+/** Simple `{ message }` success/error bodies (bookmarks, etc.). */
+export const messageResponseSchema = z.object({
+	message: z.string()
 });
 
 export function jsonBody(schema: z.ZodType) {
@@ -233,8 +231,15 @@ export const podcastChangeRequestSchema = z.object({
 	minimumDuration: z.string().optional().nullable()
 });
 
-/** Unmodelled admin request blobs only. */
-export const opaqueObjectRequestSchema = z.record(z.string(), z.unknown());
+/** Unmodelled admin request blobs only — prefer empty object when Azure ignores body. */
+export const emptyObjectSchema = z.object({});
+
+/** Api.Models.EpisodePublishRequest */
+export const episodePublishRequestSchema = z.object({
+	post: z.boolean(),
+	tweet: z.boolean(),
+	blueskyPost: z.boolean()
+});
 
 // --- Azure Functions response DTOs (Cloud/Api/Dtos) ---
 
@@ -484,4 +489,52 @@ export const episodeDeleteBlockedSchema = z.object({
 	message: z.string().optional(),
 	posted: z.boolean().optional(),
 	tweeted: z.boolean().optional()
+});
+
+/** R2 `subjects` publish — SubjectsPublisher serialises name-only rows. */
+export const subjectsNameListResponseSchema = z.array(z.object({
+	name: z.string()
+}));
+
+/** ContentPublisher DiscoveryInfo (R2 `discovery-info`). */
+export const discoveryInfoResponseSchema = z.object({
+	documentCount: z.number(),
+	numberOfResults: z.number().optional().nullable(),
+	discoveryBegan: z.string().optional().nullable()
+});
+
+/** Worker IPageDetails / getPageDetails. */
+export const pageDetailsResponseSchema = z.object({
+	title: z.string().optional(),
+	description: z.string().optional(),
+	releaseDate: z.string().optional(),
+	duration: z.string().optional()
+});
+
+/**
+ * Azure Search hit — EpisodeSearchRecord camelCase fields returned to clients
+ * (hidden search-term fields omitted).
+ */
+export const episodeSearchHitSchema = z.object({
+	id: z.string(),
+	episodeTitle: z.string(),
+	podcastName: z.string(),
+	episodeDescription: z.string(),
+	release: z.string(),
+	duration: z.string(),
+	spotifyId: z.string().optional().nullable(),
+	appleId: z.string().optional().nullable(),
+	podcastAppleId: z.string().optional().nullable(),
+	youtubeId: z.string().optional().nullable(),
+	bbc: z.string().optional(),
+	internetArchive: z.string().optional(),
+	subjects: z.array(z.string()).optional(),
+	image: z.string().optional().nullable(),
+	"@search.score": z.number().optional()
+});
+
+/** Azure Search POST response (worker strips @odata.context). */
+export const searchResponseSchema = z.object({
+	"@odata.count": z.number().optional(),
+	value: z.array(episodeSearchHitSchema)
 });

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -599,5 +599,14 @@ export const homepageResponseSchema = z.object({
 	totalDuration: z.string()
 });
 
-/** R2 `homepage-ssr` — pre-rendered HTML document. */
-export const homepageSsrResponseSchema = z.string();
+/**
+ * R2 `homepage-ssr` (PreProcessedHomepageKey) —
+ * RedditPodcastPoster.Models.HomePage.PreProcessedHomePageModel (JSON, not HTML).
+ */
+export const preProcessedHomepageResponseSchema = z.object({
+	totalDurationDays: z.number(),
+	episodesByDay: z.record(z.string(), z.array(homepageEpisodeSchema)),
+	hasNext: z.boolean(),
+	episodesThisWeek: z.number(),
+	episodeCount: z.number()
+});

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -265,9 +265,6 @@ export const podcastChangeRequestSchema = z.object({
 	minimumDuration: z.string().optional().nullable()
 });
 
-/** Unmodelled admin request blobs only — prefer empty object when Azure ignores body. */
-export const emptyObjectSchema = z.object({});
-
 /** Api.Models.EpisodePublishRequest */
 export const episodePublishRequestSchema = z.object({
 	post: z.boolean(),

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -138,7 +138,7 @@ export const pushSubscriptionRequestSchema = z.object({
 	})
 });
 
-/** ServiceUrls — Api.Dtos / RedditPodcastPoster.Models.Podcasts */
+/** ServiceUrls — RedditPodcastPoster.Models.Podcasts.ServiceUrls (response / absolute URIs). */
 export const serviceUrlsSchema = z.object({
 	spotify: z.string().url().optional().nullable(),
 	apple: z.string().url().optional().nullable(),
@@ -147,13 +147,45 @@ export const serviceUrlsSchema = z.object({
 	bbc: z.string().url().optional().nullable()
 });
 
-export const episodeImagesSchema = z.object({
-	youtube: z.string().url().optional().nullable(),
+/** ServiceImageUrls — RedditPodcastPoster.Models.Podcasts.ServiceImageUrls */
+export const serviceImageUrlsSchema = z.object({
 	spotify: z.string().url().optional().nullable(),
 	apple: z.string().url().optional().nullable(),
+	youtube: z.string().url().optional().nullable(),
 	other: z.string().url().optional().nullable()
 });
 
+/** @deprecated Prefer serviceImageUrlsSchema */
+export const episodeImagesSchema = serviceImageUrlsSchema;
+
+/**
+ * Patch URI: absolute URL, empty string (Angular clears with ''), or null.
+ * Mirrors System.Uri? JSON on EpisodeChangeRequest.urls / images.
+ */
+const patchUriSchema = z.union([z.string().url(), z.literal(""), z.null()]).optional();
+
+const serviceUrlsChangeSchema = z.object({
+	spotify: patchUriSchema,
+	apple: patchUriSchema,
+	youtube: patchUriSchema,
+	internetArchive: patchUriSchema,
+	bbc: patchUriSchema
+});
+
+const serviceImageUrlsChangeSchema = z.object({
+	spotify: patchUriSchema,
+	apple: patchUriSchema,
+	youtube: patchUriSchema,
+	other: patchUriSchema
+});
+
+/** JsonStringEnumConverter — RedditPodcastPoster.Models.Podcasts.Service */
+export const serviceEnumSchema = z.enum(["Spotify", "Apple", "YouTube", "Other"]);
+
+/** JsonStringEnumConverter — RedditPodcastPoster.Models.Subjects.SubjectType */
+export const subjectTypeSchema = z.enum(["Unset", "Canonical", "Meta"]);
+
+/** Api.Models.EpisodeChangeRequest */
 export const episodeChangeRequestSchema = z.object({
 	title: z.string().optional().nullable(),
 	description: z.string().optional().nullable(),
@@ -165,14 +197,15 @@ export const episodeChangeRequestSchema = z.object({
 	explicit: z.boolean().optional().nullable(),
 	release: z.string().optional().nullable(),
 	duration: z.string().optional().nullable(),
-	urls: serviceUrlsSchema.optional().nullable(),
-	images: episodeImagesSchema.optional().nullable(),
+	urls: serviceUrlsChangeSchema.optional().nullable(),
+	images: serviceImageUrlsChangeSchema.optional().nullable(),
 	subjects: z.array(z.string()).optional().nullable(),
 	searchTerms: z.string().optional().nullable(),
 	lang: z.string().optional().nullable(),
 	guests: z.array(z.string()).optional().nullable()
 });
 
+/** Api.Models.PersonChangeRequest */
 export const personChangeRequestSchema = z.object({
 	id: z.string().uuid().optional().nullable(),
 	name: z.string().optional().nullable(),
@@ -183,6 +216,7 @@ export const personChangeRequestSchema = z.object({
 	blueskyHandle: z.string().optional().nullable()
 });
 
+/** Api.Models.SubjectChangeRequest */
 export const subjectChangeRequestSchema = z.object({
 	id: z.string().uuid().optional().nullable(),
 	aliases: z.array(z.string()).optional().nullable(),
@@ -192,11 +226,11 @@ export const subjectChangeRequestSchema = z.object({
 	hashTag: z.string().optional().nullable(),
 	redditFlairTemplateId: z.string().uuid().optional().nullable(),
 	redditFlareText: z.string().optional().nullable(),
-	subjectType: z.string().optional().nullable(),
+	subjectType: subjectTypeSchema.optional().nullable(),
 	knownTerms: z.array(z.string()).optional().nullable()
 });
 
-/** Large patch surface — known keys only (matches PodcastDto / change request). */
+/** Api.Models.PodcastChangeRequest */
 export const podcastChangeRequestSchema = z.object({
 	id: z.string().uuid().optional().nullable(),
 	name: z.string().optional().nullable(),
@@ -204,12 +238,12 @@ export const podcastChangeRequestSchema = z.object({
 	removed: z.boolean().optional().nullable(),
 	indexAllEpisodes: z.boolean().optional().nullable(),
 	bypassShortEpisodeChecking: z.boolean().optional().nullable(),
-	releaseAuthority: z.string().optional().nullable(),
+	releaseAuthority: serviceEnumSchema.optional().nullable(),
 	unsetReleaseAuthority: z.boolean().optional().nullable(),
-	primaryPostService: z.string().optional().nullable(),
+	primaryPostService: serviceEnumSchema.optional().nullable(),
 	unsetPrimaryPostService: z.boolean().optional().nullable(),
 	spotifyId: z.string().optional().nullable(),
-	appleId: z.number().optional().nullable(),
+	appleId: z.number().int().optional().nullable(),
 	nullAppleId: z.boolean().optional().nullable(),
 	youTubePublicationDelay: z.string().optional().nullable(),
 	skipEnrichingFromYouTube: z.boolean().optional().nullable(),
@@ -255,7 +289,7 @@ export const searchIndexerStateSchema = z.enum([
 ]);
 
 /** JsonStringEnumConverter Service values used on EpisodeDto / PodcastDto. */
-export const serviceNameSchema = z.string();
+export const serviceNameSchema = serviceEnumSchema;
 
 export const personDtoSchema = z.object({
 	id: z.string().uuid().optional().nullable(),
@@ -311,7 +345,7 @@ export const episodeDtoSchema = z.object({
 	removedSubjects: z.array(z.string()).optional(),
 	matches: z.array(episodeSubjectMatchSchema).optional(),
 	searchTerms: z.string().optional().nullable(),
-	images: episodeImagesSchema.optional().nullable(),
+	images: serviceImageUrlsSchema.optional().nullable(),
 	guests: z.array(z.string()).optional().nullable(),
 	youTubePodcast: z.boolean().optional(),
 	spotifyPodcast: z.boolean().optional(),
@@ -365,7 +399,7 @@ export const subjectDtoSchema = z.object({
 	hashTag: z.string().optional().nullable(),
 	redditFlairTemplateId: z.string().uuid().optional().nullable(),
 	redditFlareText: z.string().optional().nullable(),
-	subjectType: z.string().optional().nullable(),
+	subjectType: subjectTypeSchema.optional().nullable(),
 	knownTerms: z.array(z.string()).optional().nullable()
 });
 
@@ -377,9 +411,9 @@ export const podcastDtoSchema = z.object({
 	removed: z.boolean().optional().nullable(),
 	indexAllEpisodes: z.boolean().optional().nullable(),
 	bypassShortEpisodeChecking: z.boolean().optional().nullable(),
-	releaseAuthority: serviceNameSchema.optional().nullable(),
+	releaseAuthority: serviceEnumSchema.optional().nullable(),
 	unsetReleaseAuthority: z.boolean().optional().nullable(),
-	primaryPostService: serviceNameSchema.optional().nullable(),
+	primaryPostService: serviceEnumSchema.optional().nullable(),
 	unsetPrimaryPostService: z.boolean().optional().nullable(),
 	spotifyId: z.string().optional().nullable(),
 	appleId: z.number().optional().nullable(),

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -572,3 +572,35 @@ export const searchResponseSchema = z.object({
 	"@odata.count": z.number().optional(),
 	value: z.array(episodeSearchHitSchema)
 });
+
+/**
+ * R2 `homepage` — RedditPodcastPoster.Models.HomePage.HomePageModel /
+ * RecentEpisode (camelCase; TimeSpan as string).
+ */
+export const homepageEpisodeSchema = z.object({
+	id: z.string().uuid(),
+	episodeId: z.string().uuid().optional(),
+	podcastName: z.string(),
+	episodeTitle: z.string(),
+	episodeDescription: z.string(),
+	length: z.string().optional(),
+	duration: z.string(),
+	release: z.string(),
+	releaseDayDisplay: z.string().optional(),
+	spotify: z.string().url().optional().nullable(),
+	apple: z.string().url().optional().nullable(),
+	youtube: z.string().url().optional().nullable(),
+	bbc: z.string().url().optional().nullable(),
+	internetArchive: z.string().url().optional().nullable(),
+	subjects: z.array(z.string()).optional().nullable(),
+	image: z.string().url().optional().nullable()
+});
+
+export const homepageResponseSchema = z.object({
+	recentEpisodes: z.array(homepageEpisodeSchema),
+	episodeCount: z.number(),
+	totalDuration: z.string()
+});
+
+/** R2 `homepage-ssr` — pre-rendered HTML document. */
+export const homepageSsrResponseSchema = z.string();

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -2,8 +2,9 @@ import { z } from "zod";
 
 /**
  * OpenAPI/Zod contracts for the Cloudflare Api worker.
- * Incremental: concrete request bodies for known Azure/DTO shapes;
- * opaque JSON for responses not yet modelled end-to-end.
+ * Known Azure/DTO shapes are strict objects (no `.passthrough()` / open records) so
+ * Swagger examples show real fields instead of additionalProp1/2/3.
+ * `opaqueJsonSchema` / `opaqueObjectRequestSchema` remain only for unmodelled blobs.
  */
 
 /** Prefer over `z.any()` — documents "some JSON" without claiming a shape. */
@@ -33,7 +34,7 @@ export const searchRequestSchema = z.object({
 	filter: z.string().optional(),
 	skip: z.string().optional(),
 	orderby: z.string().optional()
-}).passthrough();
+});
 
 export const submitUrlRequestSchema = z.object({
 	url: z.string().url(),
@@ -139,6 +140,22 @@ export const pushSubscriptionRequestSchema = z.object({
 	})
 });
 
+/** ServiceUrls — Api.Dtos / RedditPodcastPoster.Models.Podcasts */
+export const serviceUrlsSchema = z.object({
+	spotify: z.string().url().optional().nullable(),
+	apple: z.string().url().optional().nullable(),
+	youtube: z.string().url().optional().nullable(),
+	internetArchive: z.string().url().optional().nullable(),
+	bbc: z.string().url().optional().nullable()
+});
+
+export const episodeImagesSchema = z.object({
+	youtube: z.string().url().optional().nullable(),
+	spotify: z.string().url().optional().nullable(),
+	apple: z.string().url().optional().nullable(),
+	other: z.string().url().optional().nullable()
+});
+
 export const episodeChangeRequestSchema = z.object({
 	title: z.string().optional().nullable(),
 	description: z.string().optional().nullable(),
@@ -150,13 +167,13 @@ export const episodeChangeRequestSchema = z.object({
 	explicit: z.boolean().optional().nullable(),
 	release: z.string().optional().nullable(),
 	duration: z.string().optional().nullable(),
-	urls: z.record(z.string(), z.unknown()).optional().nullable(),
-	images: z.record(z.string(), z.unknown()).optional().nullable(),
+	urls: serviceUrlsSchema.optional().nullable(),
+	images: episodeImagesSchema.optional().nullable(),
 	subjects: z.array(z.string()).optional().nullable(),
 	searchTerms: z.string().optional().nullable(),
 	lang: z.string().optional().nullable(),
 	guests: z.array(z.string()).optional().nullable()
-}).passthrough();
+});
 
 export const personChangeRequestSchema = z.object({
 	id: z.string().uuid().optional().nullable(),
@@ -166,7 +183,7 @@ export const personChangeRequestSchema = z.object({
 	aliases: z.array(z.string()).optional().nullable(),
 	twitterHandle: z.string().optional().nullable(),
 	blueskyHandle: z.string().optional().nullable()
-}).passthrough();
+});
 
 export const subjectChangeRequestSchema = z.object({
 	id: z.string().uuid().optional().nullable(),
@@ -179,9 +196,9 @@ export const subjectChangeRequestSchema = z.object({
 	redditFlareText: z.string().optional().nullable(),
 	subjectType: z.string().optional().nullable(),
 	knownTerms: z.array(z.string()).optional().nullable()
-}).passthrough();
+});
 
-/** Large patch surface — document known keys; allow additional fields. */
+/** Large patch surface — known keys only (matches PodcastDto / change request). */
 export const podcastChangeRequestSchema = z.object({
 	id: z.string().uuid().optional().nullable(),
 	name: z.string().optional().nullable(),
@@ -214,9 +231,9 @@ export const podcastChangeRequestSchema = z.object({
 	ignoredSubjects: z.array(z.string()).optional().nullable(),
 	knownTerms: z.array(z.string()).optional().nullable(),
 	minimumDuration: z.string().optional().nullable()
-}).passthrough();
+});
 
-/** Homepage publish / other admin blobs not yet fully modelled. */
+/** Unmodelled admin request blobs only. */
 export const opaqueObjectRequestSchema = z.record(z.string(), z.unknown());
 
 // --- Azure Functions response DTOs (Cloud/Api/Dtos) ---
@@ -235,14 +252,6 @@ export const searchIndexerStateSchema = z.enum([
 /** JsonStringEnumConverter Service values used on EpisodeDto / PodcastDto. */
 export const serviceNameSchema = z.string();
 
-export const serviceUrlsSchema = z.object({
-	spotify: z.string().url().optional().nullable(),
-	apple: z.string().url().optional().nullable(),
-	youtube: z.string().url().optional().nullable(),
-	internetArchive: z.string().url().optional().nullable(),
-	bbc: z.string().url().optional().nullable()
-}).passthrough();
-
 export const personDtoSchema = z.object({
 	id: z.string().uuid().optional().nullable(),
 	name: z.string().optional().nullable(),
@@ -251,7 +260,7 @@ export const personDtoSchema = z.object({
 	aliases: z.array(z.string()).optional().nullable(),
 	twitterHandle: z.string().optional().nullable(),
 	blueskyHandle: z.string().optional().nullable()
-}).passthrough();
+});
 
 export const peopleListResponseSchema = z.array(personDtoSchema);
 
@@ -263,20 +272,13 @@ const episodeGuestMatchResultSchema = z.object({
 const episodeGuestSuggestionSchema = z.object({
 	person: personDtoSchema,
 	matchResults: z.array(episodeGuestMatchResultSchema)
-}).passthrough();
+});
 
 const episodeSubjectMatchSchema = z.object({
 	subject: z.string().optional(),
 	term: z.string().optional(),
 	source: z.string().optional()
-}).passthrough();
-
-const episodeImagesSchema = z.object({
-	youtube: z.string().url().optional().nullable(),
-	spotify: z.string().url().optional().nullable(),
-	apple: z.string().url().optional().nullable(),
-	other: z.string().url().optional().nullable()
-}).passthrough();
+});
 
 /** Api.Dtos.EpisodeDto — TimeSpan `duration` serialises as string (e.g. "01:30:00"). */
 export const episodeDtoSchema = z.object({
@@ -314,7 +316,7 @@ export const episodeDtoSchema = z.object({
 	image: z.string().url().optional().nullable(),
 	guestPeople: z.array(personDtoSchema).optional().nullable(),
 	guestSuggestions: z.array(episodeGuestSuggestionSchema).optional().nullable()
-}).passthrough();
+});
 
 export const episodeListResponseSchema = z.array(episodeDtoSchema);
 
@@ -330,14 +332,14 @@ export const publicEpisodeDtoSchema = z.object({
 	subjects: z.array(z.string()),
 	urls: serviceUrlsSchema,
 	image: z.string().url().optional().nullable()
-}).passthrough();
+});
 
 /** Api.Dtos.EpisodeUpdateResponse — POST episode → 202 */
 export const episodeUpdateResponseSchema = z.object({
 	tweetDeleted: z.boolean().optional().nullable(),
 	blueskyPostDeleted: z.boolean().optional().nullable(),
 	searchIndexerState: searchIndexerStateSchema.optional().nullable()
-}).passthrough();
+});
 
 /** Api.Dtos.EpisodePublishResponse */
 export const episodePublishResponseSchema = z.object({
@@ -346,7 +348,7 @@ export const episodePublishResponseSchema = z.object({
 	blueskyPosted: z.boolean().optional().nullable(),
 	failedTweetContent: z.string().optional().nullable(),
 	podcastId: z.string().uuid().optional().nullable()
-}).passthrough();
+});
 
 /** Api.Dtos.SubjectDto */
 export const subjectDtoSchema = z.object({
@@ -360,7 +362,7 @@ export const subjectDtoSchema = z.object({
 	redditFlareText: z.string().optional().nullable(),
 	subjectType: z.string().optional().nullable(),
 	knownTerms: z.array(z.string()).optional().nullable()
-}).passthrough();
+});
 
 /** Api.Dtos.PodcastDto */
 export const podcastDtoSchema = z.object({
@@ -395,7 +397,7 @@ export const podcastDtoSchema = z.object({
 	ignoredSubjects: z.array(z.string()).optional().nullable(),
 	knownTerms: z.array(z.string()).optional().nullable(),
 	minimumDuration: z.string().optional().nullable()
-}).passthrough();
+});
 
 /** Api.Dtos.DiscoverySubmitResponse */
 export const discoverySubmitResponseSchema = z.object({
@@ -406,20 +408,20 @@ export const discoverySubmitResponseSchema = z.object({
 		podcastId: z.string().uuid().optional().nullable(),
 		episodeId: z.string().uuid().optional().nullable(),
 		message: z.string()
-	}).passthrough()),
+	})),
 	searchIndexerState: searchIndexerStateSchema
-}).passthrough();
+});
 
 /** Api.Dtos.PublishHomepageResponse */
 export const publishHomepageResponseSchema = z.object({
 	homepagePublished: z.boolean(),
 	preProcessedHomepagePublished: z.boolean().optional().nullable()
-}).passthrough();
+});
 
 /** Api.Dtos.PodcastRenameResponse */
 export const podcastRenameResponseSchema = z.object({
 	indexState: searchIndexerStateSchema
-}).passthrough();
+});
 
 /** Api.Dtos.IndexPodcastResponse */
 export const indexPodcastResponseSchema = z.object({
@@ -430,17 +432,17 @@ export const indexPodcastResponseSchema = z.object({
 		apple: z.boolean(),
 		youtube: z.boolean(),
 		subjects: z.array(z.string())
-	}).passthrough()).optional().nullable(),
+	})).optional().nullable(),
 	indexStatus: z.string(),
 	searchIndexerState: searchIndexerStateSchema.optional()
-}).passthrough();
+});
 
 /** Api.Dtos.IndexerStateDto */
 export const indexerStateDtoSchema = z.object({
 	state: z.string(),
 	nextRun: z.string().optional().nullable(),
 	lastRan: z.string().optional().nullable()
-}).passthrough();
+});
 
 const submitUrlItemStateSchema = z.enum([
 	"None",
@@ -472,14 +474,14 @@ export const submitUrlResponseSchema = z.object({
 					matches: z.number()
 				}))
 			})).optional().nullable()
-		}).passthrough().optional().nullable()
-	}).passthrough().optional().nullable(),
+		}).optional().nullable()
+	}).optional().nullable(),
 	error: z.string().optional().nullable()
-}).passthrough();
+});
 
 /** Delete episode 400 body when social posts block delete. */
 export const episodeDeleteBlockedSchema = z.object({
 	message: z.string().optional(),
 	posted: z.boolean().optional(),
 	tweeted: z.boolean().optional()
-}).passthrough();
+});

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -218,3 +218,268 @@ export const podcastChangeRequestSchema = z.object({
 
 /** Homepage publish / other admin blobs not yet fully modelled. */
 export const opaqueObjectRequestSchema = z.record(z.string(), z.unknown());
+
+// --- Azure Functions response DTOs (Cloud/Api/Dtos) ---
+
+export const searchIndexerStateSchema = z.enum([
+	"EpisodeNotFound",
+	"EpisodeIdConflict",
+	"NoDocuments",
+	"Executed",
+	"Failure",
+	"TooManyRequests",
+	"AlreadyRunning",
+	"Unknown"
+]);
+
+/** JsonStringEnumConverter Service values used on EpisodeDto / PodcastDto. */
+export const serviceNameSchema = z.string();
+
+export const serviceUrlsSchema = z.object({
+	spotify: z.string().url().optional().nullable(),
+	apple: z.string().url().optional().nullable(),
+	youtube: z.string().url().optional().nullable(),
+	internetArchive: z.string().url().optional().nullable(),
+	bbc: z.string().url().optional().nullable()
+}).passthrough();
+
+export const personDtoSchema = z.object({
+	id: z.string().uuid().optional().nullable(),
+	name: z.string().optional().nullable(),
+	sortName: z.string().optional().nullable(),
+	isOrganization: z.boolean().optional().nullable(),
+	aliases: z.array(z.string()).optional().nullable(),
+	twitterHandle: z.string().optional().nullable(),
+	blueskyHandle: z.string().optional().nullable()
+}).passthrough();
+
+export const peopleListResponseSchema = z.array(personDtoSchema);
+
+const episodeGuestMatchResultSchema = z.object({
+	term: z.string(),
+	matches: z.number()
+});
+
+const episodeGuestSuggestionSchema = z.object({
+	person: personDtoSchema,
+	matchResults: z.array(episodeGuestMatchResultSchema)
+}).passthrough();
+
+const episodeSubjectMatchSchema = z.object({
+	subject: z.string().optional(),
+	term: z.string().optional(),
+	source: z.string().optional()
+}).passthrough();
+
+const episodeImagesSchema = z.object({
+	youtube: z.string().url().optional().nullable(),
+	spotify: z.string().url().optional().nullable(),
+	apple: z.string().url().optional().nullable(),
+	other: z.string().url().optional().nullable()
+}).passthrough();
+
+/** Api.Dtos.EpisodeDto — TimeSpan `duration` serialises as string (e.g. "01:30:00"). */
+export const episodeDtoSchema = z.object({
+	id: z.string().uuid(),
+	podcastId: z.string().uuid(),
+	podcastName: z.string(),
+	title: z.string(),
+	displayTitle: z.string().optional(),
+	description: z.string(),
+	displayDescription: z.string().optional(),
+	release: z.string(),
+	duration: z.string(),
+	explicit: z.boolean(),
+	posted: z.boolean(),
+	tweeted: z.boolean(),
+	bluesky: z.boolean().optional().nullable(),
+	ignored: z.boolean(),
+	removed: z.boolean(),
+	lang: z.string().optional().nullable(),
+	spotifyId: z.string().optional(),
+	appleId: z.number().optional().nullable(),
+	youTubeId: z.string().optional(),
+	urls: serviceUrlsSchema,
+	subjects: z.array(z.string()),
+	removedSubjects: z.array(z.string()).optional(),
+	matches: z.array(episodeSubjectMatchSchema).optional(),
+	searchTerms: z.string().optional().nullable(),
+	images: episodeImagesSchema.optional().nullable(),
+	guests: z.array(z.string()).optional().nullable(),
+	youTubePodcast: z.boolean().optional(),
+	spotifyPodcast: z.boolean().optional(),
+	applePodcast: z.boolean().optional(),
+	releaseAuthority: serviceNameSchema.optional().nullable(),
+	primaryPostService: serviceNameSchema.optional().nullable(),
+	image: z.string().url().optional().nullable(),
+	guestPeople: z.array(personDtoSchema).optional().nullable(),
+	guestSuggestions: z.array(episodeGuestSuggestionSchema).optional().nullable()
+}).passthrough();
+
+export const episodeListResponseSchema = z.array(episodeDtoSchema);
+
+/** Api.Dtos.PublicEpisodeDto */
+export const publicEpisodeDtoSchema = z.object({
+	id: z.string().uuid(),
+	podcastName: z.string(),
+	title: z.string(),
+	description: z.string(),
+	release: z.string(),
+	duration: z.string(),
+	explicit: z.boolean(),
+	subjects: z.array(z.string()),
+	urls: serviceUrlsSchema,
+	image: z.string().url().optional().nullable()
+}).passthrough();
+
+/** Api.Dtos.EpisodeUpdateResponse — POST episode → 202 */
+export const episodeUpdateResponseSchema = z.object({
+	tweetDeleted: z.boolean().optional().nullable(),
+	blueskyPostDeleted: z.boolean().optional().nullable(),
+	searchIndexerState: searchIndexerStateSchema.optional().nullable()
+}).passthrough();
+
+/** Api.Dtos.EpisodePublishResponse */
+export const episodePublishResponseSchema = z.object({
+	posted: z.boolean().optional().nullable(),
+	tweeted: z.boolean().optional().nullable(),
+	blueskyPosted: z.boolean().optional().nullable(),
+	failedTweetContent: z.string().optional().nullable(),
+	podcastId: z.string().uuid().optional().nullable()
+}).passthrough();
+
+/** Api.Dtos.SubjectDto */
+export const subjectDtoSchema = z.object({
+	id: z.string().uuid().optional().nullable(),
+	aliases: z.array(z.string()).optional().nullable(),
+	associatedSubjects: z.array(z.string()).optional().nullable(),
+	name: z.string().optional().nullable(),
+	enrichmentHashTags: z.array(z.string()).optional().nullable(),
+	hashTag: z.string().optional().nullable(),
+	redditFlairTemplateId: z.string().uuid().optional().nullable(),
+	redditFlareText: z.string().optional().nullable(),
+	subjectType: z.string().optional().nullable(),
+	knownTerms: z.array(z.string()).optional().nullable()
+}).passthrough();
+
+/** Api.Dtos.PodcastDto */
+export const podcastDtoSchema = z.object({
+	id: z.string().uuid().optional().nullable(),
+	name: z.string().optional().nullable(),
+	lang: z.string().optional().nullable(),
+	removed: z.boolean().optional().nullable(),
+	indexAllEpisodes: z.boolean().optional().nullable(),
+	bypassShortEpisodeChecking: z.boolean().optional().nullable(),
+	releaseAuthority: serviceNameSchema.optional().nullable(),
+	unsetReleaseAuthority: z.boolean().optional().nullable(),
+	primaryPostService: serviceNameSchema.optional().nullable(),
+	unsetPrimaryPostService: z.boolean().optional().nullable(),
+	spotifyId: z.string().optional().nullable(),
+	appleId: z.number().optional().nullable(),
+	nullAppleId: z.boolean().optional().nullable(),
+	youTubePublicationDelay: z.string().optional().nullable(),
+	skipEnrichingFromYouTube: z.boolean().optional().nullable(),
+	twitterHandle: z.string().optional().nullable(),
+	blueskyHandle: z.string().optional().nullable(),
+	enrichmentHashTags: z.array(z.string()).optional().nullable(),
+	hashTag: z.string().optional().nullable(),
+	titleRegex: z.string().optional().nullable(),
+	descriptionRegex: z.string().optional().nullable(),
+	episodeMatchRegex: z.string().optional().nullable(),
+	episodeIncludeTitleRegex: z.string().optional().nullable(),
+	defaultSubject: z.string().optional().nullable(),
+	ignoreAllEpisodes: z.boolean().optional().nullable(),
+	youTubeChannelId: z.string().optional().nullable(),
+	youTubePlaylistId: z.string().optional().nullable(),
+	ignoredAssociatedSubjects: z.array(z.string()).optional().nullable(),
+	ignoredSubjects: z.array(z.string()).optional().nullable(),
+	knownTerms: z.array(z.string()).optional().nullable(),
+	minimumDuration: z.string().optional().nullable()
+}).passthrough();
+
+/** Api.Dtos.DiscoverySubmitResponse */
+export const discoverySubmitResponseSchema = z.object({
+	message: z.string(),
+	errorsOccurred: z.boolean(),
+	results: z.array(z.object({
+		discoveryItemId: z.string().uuid(),
+		podcastId: z.string().uuid().optional().nullable(),
+		episodeId: z.string().uuid().optional().nullable(),
+		message: z.string()
+	}).passthrough()),
+	searchIndexerState: searchIndexerStateSchema
+}).passthrough();
+
+/** Api.Dtos.PublishHomepageResponse */
+export const publishHomepageResponseSchema = z.object({
+	homepagePublished: z.boolean(),
+	preProcessedHomepagePublished: z.boolean().optional().nullable()
+}).passthrough();
+
+/** Api.Dtos.PodcastRenameResponse */
+export const podcastRenameResponseSchema = z.object({
+	indexState: searchIndexerStateSchema
+}).passthrough();
+
+/** Api.Dtos.IndexPodcastResponse */
+export const indexPodcastResponseSchema = z.object({
+	indexedEpisodes: z.array(z.object({
+		podcastId: z.string().uuid(),
+		episodeId: z.string().uuid(),
+		spotify: z.boolean(),
+		apple: z.boolean(),
+		youtube: z.boolean(),
+		subjects: z.array(z.string())
+	}).passthrough()).optional().nullable(),
+	indexStatus: z.string(),
+	searchIndexerState: searchIndexerStateSchema.optional()
+}).passthrough();
+
+/** Api.Dtos.IndexerStateDto */
+export const indexerStateDtoSchema = z.object({
+	state: z.string(),
+	nextRun: z.string().optional().nullable(),
+	lastRan: z.string().optional().nullable()
+}).passthrough();
+
+const submitUrlItemStateSchema = z.enum([
+	"None",
+	"Created",
+	"Enriched",
+	"Ignored",
+	"EpisodeAlreadyExists"
+]);
+
+/** Api.Dtos.SubmitUrlResponse */
+export const submitUrlResponseSchema = z.object({
+	success: z.object({
+		episode: submitUrlItemStateSchema,
+		episodeId: z.string().uuid().optional().nullable(),
+		podcastId: z.string().uuid().optional().nullable(),
+		podcast: submitUrlItemStateSchema,
+		episodeDetails: z.object({
+			spotify: z.boolean(),
+			apple: z.boolean(),
+			youtube: z.boolean(),
+			bbc: z.boolean(),
+			internetArchive: z.boolean(),
+			subjects: z.array(z.string()).optional().nullable(),
+			people: z.array(z.string()).optional().nullable(),
+			guestSuggestions: z.array(z.object({
+				name: z.string(),
+				matchResults: z.array(z.object({
+					term: z.string(),
+					matches: z.number()
+				}))
+			})).optional().nullable()
+		}).passthrough().optional().nullable()
+	}).passthrough().optional().nullable(),
+	error: z.string().optional().nullable()
+}).passthrough();
+
+/** Delete episode 400 body when social posts block delete. */
+export const episodeDeleteBlockedSchema = z.object({
+	message: z.string().optional(),
+	posted: z.boolean().optional(),
+	tweeted: z.boolean().optional()
+}).passthrough();

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -1,0 +1,162 @@
+import { z } from "zod";
+
+/**
+ * OpenAPI/Zod contracts for the Cloudflare Api worker.
+ * Incremental: concrete request bodies for known Azure/DTO shapes;
+ * opaque JSON for responses not yet modelled end-to-end.
+ */
+
+/** Prefer over `z.any()` — documents "some JSON" without claiming a shape. */
+export const opaqueJsonSchema = z.union([
+	z.record(z.string(), z.unknown()),
+	z.array(z.unknown())
+]);
+
+export const errorSchema = z.object({
+	error: z.string().optional(),
+	message: z.string().optional()
+});
+
+export function jsonBody(schema: z.ZodType) {
+	return {
+		content: {
+			"application/json": {
+				schema
+			}
+		},
+		required: true
+	} as const;
+}
+
+export const searchRequestSchema = z.object({
+	search: z.string().optional(),
+	filter: z.string().optional(),
+	skip: z.string().optional(),
+	orderby: z.string().optional()
+}).passthrough();
+
+export const submitUrlRequestSchema = z.object({
+	url: z.string().url(),
+	podcastId: z.string().uuid().optional().nullable(),
+	podcastName: z.string().optional().nullable()
+});
+
+export const discoverySubmitRequestSchema = z.object({
+	ids: z.array(z.string().uuid()),
+	resultIds: z.array(z.string().uuid())
+});
+
+export const discoveryScheduleUpdateRequestSchema = z.object({
+	runTimes: z.array(z.string()),
+	timeZoneId: z.string().optional().nullable(),
+	enabled: z.boolean().optional().nullable()
+});
+
+export const discoveryScheduleResponseSchema = z.object({
+	runTimes: z.array(z.string()),
+	timeZoneId: z.string(),
+	enabled: z.boolean(),
+	isDefault: z.boolean(),
+	nextRuns: z.array(z.object({
+		slotId: z.string(),
+		slotStartUtc: z.string(),
+		slotStartUk: z.string()
+	}))
+});
+
+export const termSubmitRequestSchema = z.object({
+	term: z.string().min(1)
+});
+
+export const podcastRenameRequestSchema = z.object({
+	newPodcastName: z.string().min(1)
+});
+
+export const pushSubscriptionRequestSchema = z.object({
+	endpoint: z.string().url(),
+	expirationTime: z.number().optional().nullable(),
+	keys: z.object({
+		auth: z.string(),
+		p256dh: z.string()
+	})
+});
+
+export const episodeChangeRequestSchema = z.object({
+	title: z.string().optional().nullable(),
+	description: z.string().optional().nullable(),
+	posted: z.boolean().optional().nullable(),
+	tweeted: z.boolean().optional().nullable(),
+	bluesky: z.boolean().optional().nullable(),
+	ignored: z.boolean().optional().nullable(),
+	removed: z.boolean().optional().nullable(),
+	explicit: z.boolean().optional().nullable(),
+	release: z.string().optional().nullable(),
+	duration: z.string().optional().nullable(),
+	urls: z.record(z.string(), z.unknown()).optional().nullable(),
+	images: z.record(z.string(), z.unknown()).optional().nullable(),
+	subjects: z.array(z.string()).optional().nullable(),
+	searchTerms: z.string().optional().nullable(),
+	lang: z.string().optional().nullable(),
+	guests: z.array(z.string()).optional().nullable()
+}).passthrough();
+
+export const personChangeRequestSchema = z.object({
+	id: z.string().uuid().optional().nullable(),
+	name: z.string().optional().nullable(),
+	sortName: z.string().optional().nullable(),
+	isOrganization: z.boolean().optional().nullable(),
+	aliases: z.array(z.string()).optional().nullable(),
+	twitterHandle: z.string().optional().nullable(),
+	blueskyHandle: z.string().optional().nullable()
+}).passthrough();
+
+export const subjectChangeRequestSchema = z.object({
+	id: z.string().uuid().optional().nullable(),
+	aliases: z.array(z.string()).optional().nullable(),
+	associatedSubjects: z.array(z.string()).optional().nullable(),
+	name: z.string().optional().nullable(),
+	enrichmentHashTags: z.array(z.string()).optional().nullable(),
+	hashTag: z.string().optional().nullable(),
+	redditFlairTemplateId: z.string().uuid().optional().nullable(),
+	redditFlareText: z.string().optional().nullable(),
+	subjectType: z.string().optional().nullable(),
+	knownTerms: z.array(z.string()).optional().nullable()
+}).passthrough();
+
+/** Large patch surface — document known keys; allow additional fields. */
+export const podcastChangeRequestSchema = z.object({
+	id: z.string().uuid().optional().nullable(),
+	name: z.string().optional().nullable(),
+	lang: z.string().optional().nullable(),
+	removed: z.boolean().optional().nullable(),
+	indexAllEpisodes: z.boolean().optional().nullable(),
+	bypassShortEpisodeChecking: z.boolean().optional().nullable(),
+	releaseAuthority: z.string().optional().nullable(),
+	unsetReleaseAuthority: z.boolean().optional().nullable(),
+	primaryPostService: z.string().optional().nullable(),
+	unsetPrimaryPostService: z.boolean().optional().nullable(),
+	spotifyId: z.string().optional().nullable(),
+	appleId: z.number().optional().nullable(),
+	nullAppleId: z.boolean().optional().nullable(),
+	youTubePublicationDelay: z.string().optional().nullable(),
+	skipEnrichingFromYouTube: z.boolean().optional().nullable(),
+	twitterHandle: z.string().optional().nullable(),
+	blueskyHandle: z.string().optional().nullable(),
+	enrichmentHashTags: z.array(z.string()).optional().nullable(),
+	hashTag: z.string().optional().nullable(),
+	titleRegex: z.string().optional().nullable(),
+	descriptionRegex: z.string().optional().nullable(),
+	episodeMatchRegex: z.string().optional().nullable(),
+	episodeIncludeTitleRegex: z.string().optional().nullable(),
+	defaultSubject: z.string().optional().nullable(),
+	ignoreAllEpisodes: z.boolean().optional().nullable(),
+	youTubeChannelId: z.string().optional().nullable(),
+	youTubePlaylistId: z.string().optional().nullable(),
+	ignoredAssociatedSubjects: z.array(z.string()).optional().nullable(),
+	ignoredSubjects: z.array(z.string()).optional().nullable(),
+	knownTerms: z.array(z.string()).optional().nullable(),
+	minimumDuration: z.string().optional().nullable()
+}).passthrough();
+
+/** Homepage publish / other admin blobs not yet fully modelled. */
+export const opaqueObjectRequestSchema = z.record(z.string(), z.unknown());

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -64,6 +64,64 @@ export const discoveryScheduleResponseSchema = z.object({
 	}))
 });
 
+/** GET /discovery-curation — mirrors Api.Dtos.DiscoveryResponse. */
+const discoveryResultUrlsSchema = z.object({
+	spotify: z.string().url().optional().nullable(),
+	apple: z.string().url().optional().nullable(),
+	youtube: z.string().url().optional().nullable()
+});
+
+const discoverServiceSchema = z.enum(["Spotify", "ListenNotes", "YouTube", "Taddy"]);
+
+const discoveryMatchingPodcastSchema = z.object({
+	name: z.string(),
+	visible: z.boolean(),
+	visibleEpisodes: z.number()
+});
+
+const discoveryCurationItemSchema = z.object({
+	id: z.string().uuid(),
+	episodeName: z.string().optional().nullable(),
+	showName: z.string().optional().nullable(),
+	episodeDescription: z.string().optional().nullable(),
+	showDescription: z.string().optional().nullable(),
+	released: z.string(),
+	duration: z.string().optional().nullable(),
+	urls: discoveryResultUrlsSchema,
+	subjects: z.array(z.string()),
+	youTubeViews: z.number().optional().nullable(),
+	youTubeChannelMembers: z.number().optional().nullable(),
+	imageUrl: z.string().url().optional().nullable(),
+	discoverService: z.array(discoverServiceSchema),
+	enrichedTimeFromApple: z.boolean(),
+	enrichedUrlFromSpotify: z.boolean(),
+	matchingPodcasts: z.array(discoveryMatchingPodcastSchema).optional().nullable(),
+	acceptProbability: z.number().optional().nullable(),
+	autoHidden: z.boolean()
+});
+
+export const discoveryCurationResponseSchema = z.object({
+	ids: z.array(z.string().uuid()),
+	results: z.array(discoveryCurationItemSchema),
+	hiddenCount: z.number()
+});
+
+/** GET /flairs — R2 map keyed by Reddit flair template id (Guid). */
+export const flairSchema = z.object({
+	text: z.string(),
+	textEditable: z.boolean(),
+	textColour: z.string(),
+	backgroundColour: z.string()
+});
+
+export const flairsResponseSchema = z.record(z.string().uuid(), flairSchema);
+
+/** GET /languages — R2 map of ISO 639-1 code → English display name. */
+export const languagesResponseSchema = z.record(z.string(), z.string());
+
+/** GET /bookmarks — episode ids for the authenticated user. */
+export const bookmarksListResponseSchema = z.array(z.string().uuid());
+
 export const termSubmitRequestSchema = z.object({
 	term: z.string().min(1)
 });

--- a/src/proxyToAzure.ts
+++ b/src/proxyToAzure.ts
@@ -1,0 +1,82 @@
+import { Auth0ActionContext } from "./Auth0ActionContext";
+import { Auth0JwtPayload } from "./Auth0JwtPayload";
+import { buildFetchHeaders } from "./buildFetchHeaders";
+import { Endpoint } from "./Endpoint";
+import { getEndpoint } from "./endpoints";
+import { LogCollector } from "./LogCollector";
+
+export type ProxyToAzureOptions = {
+	permission: string;
+	endpoint: Endpoint;
+	method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+	/** Status codes that are returned to the client as-is (body forwarded). */
+	forwardStatuses?: number[];
+	/** Status codes treated as success (default: [200]). */
+	successStatuses?: number[];
+	body?: string;
+	appendRequestSearch?: boolean;
+	logName: string;
+};
+
+/**
+ * Shared Azure Functions proxy: permission gate + fetch + status mapping.
+ * Success and `forwardStatuses` passthrough; other non-success become Worker 500.
+ */
+export async function proxyToAzure(
+	c: Auth0ActionContext,
+	opts: ProxyToAzureOptions
+): Promise<Response> {
+	const auth0Payload: Auth0JwtPayload = c.var.auth0("payload");
+	const logCollector = new LogCollector();
+	logCollector.collectRequest(c);
+
+	const successStatuses = opts.successStatuses ?? [200];
+	const forwardStatuses = opts.forwardStatuses ?? [];
+
+	try {
+		if (auth0Payload?.permissions && auth0Payload.permissions.includes(opts.permission)) {
+			let url = getEndpoint(opts.endpoint, c.env);
+			if (opts.appendRequestSearch) {
+				const reqUrl = new URL(c.req.url);
+				if (reqUrl.search) {
+					url = new URL(url.toString() + reqUrl.search);
+				}
+			}
+
+			const init: RequestInit = {
+				headers: buildFetchHeaders(c.req, url),
+				method: opts.method
+			};
+			if (opts.body !== undefined) {
+				init.body = opts.body;
+			}
+
+			const resp = await fetch(url, init);
+			logCollector.add({ status: resp.status });
+
+			if (successStatuses.includes(resp.status) || forwardStatuses.includes(resp.status)) {
+				logCollector.addMessage(`Successfully used ${opts.logName}.`);
+				console.log(logCollector.toEndpointLog());
+				return c.newResponse(resp.body, resp.status);
+			}
+
+			logCollector.addMessage(`Failed to use ${opts.logName}.`);
+			console.error(logCollector.toEndpointLog());
+			return c.json({ error: "Error" }, 500);
+		}
+	} catch {
+		logCollector.addMessage(`Error in ${opts.logName}.`);
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "An error occurred" }, 500);
+	}
+
+	if (!auth0Payload) {
+		logCollector.addMessage(`Unauthorised to use ${opts.logName}.`);
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Unauthorised" }, 401);
+	}
+
+	logCollector.addMessage(`Forbidden to use ${opts.logName}.`);
+	console.error(logCollector.toEndpointLog());
+	return c.json({ error: "Forbidden" }, 403);
+}

--- a/src/proxyToAzure.ts
+++ b/src/proxyToAzure.ts
@@ -76,13 +76,13 @@ export async function proxyToAzure(
 			if (successStatuses.includes(resp.status) || forwardStatuses.includes(resp.status)) {
 				logCollector.addMessage(`Successfully used ${opts.logName}.`);
 				console.log(logCollector.toEndpointLog());
-				return c.newResponse(resp.body, resp.status);
+				return c.newResponse(resp.body, resp.status as Parameters<typeof c.newResponse>[1]);
 			}
 
 			if (opts.passthroughOtherStatuses) {
 				logCollector.addMessage(`Passthrough from ${opts.logName}.`);
 				console.log(logCollector.toEndpointLog());
-				return c.newResponse(resp.body, resp.status);
+				return c.newResponse(resp.body, resp.status as Parameters<typeof c.newResponse>[1]);
 			}
 
 			logCollector.addMessage(`Failed to use ${opts.logName}.`);

--- a/src/proxyToAzure.ts
+++ b/src/proxyToAzure.ts
@@ -6,21 +6,27 @@ import { getEndpoint } from "./endpoints";
 import { LogCollector } from "./LogCollector";
 
 export type ProxyToAzureOptions = {
-	permission: string;
+	/** Required permission. Omit to allow any authenticated principal. */
+	permission?: string;
 	endpoint: Endpoint;
 	method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+	/** Appended to the endpoint base URL (e.g. `/${id}`). */
+	pathSuffix?: string;
 	/** Status codes that are returned to the client as-is (body forwarded). */
 	forwardStatuses?: number[];
 	/** Status codes treated as success (default: [200]). */
 	successStatuses?: number[];
+	/** If true, any non-success status is forwarded (body + status) instead of Worker 500. */
+	passthroughOtherStatuses?: boolean;
 	body?: string;
 	appendRequestSearch?: boolean;
 	logName: string;
 };
 
 /**
- * Shared Azure Functions proxy: permission gate + fetch + status mapping.
- * Success and `forwardStatuses` passthrough; other non-success become Worker 500.
+ * Shared Azure Functions proxy: auth/permission gate + fetch + status mapping.
+ * Success and `forwardStatuses` passthrough; other non-success become Worker 500
+ * unless `passthroughOtherStatuses` is set.
  */
 export async function proxyToAzure(
 	c: Auth0ActionContext,
@@ -33,9 +39,22 @@ export async function proxyToAzure(
 	const successStatuses = opts.successStatuses ?? [200];
 	const forwardStatuses = opts.forwardStatuses ?? [];
 
+	const permitted =
+		auth0Payload != null &&
+		(opts.permission == null ||
+			(auth0Payload.permissions != null &&
+				auth0Payload.permissions.includes(opts.permission)));
+
 	try {
-		if (auth0Payload?.permissions && auth0Payload.permissions.includes(opts.permission)) {
+		if (permitted) {
 			let url = getEndpoint(opts.endpoint, c.env);
+			if (opts.pathSuffix) {
+				const base = url.toString().replace(/\/$/, "");
+				const suffix = opts.pathSuffix.startsWith("/")
+					? opts.pathSuffix
+					: `/${opts.pathSuffix}`;
+				url = new URL(`${base}${suffix}`);
+			}
 			if (opts.appendRequestSearch) {
 				const reqUrl = new URL(c.req.url);
 				if (reqUrl.search) {
@@ -56,6 +75,12 @@ export async function proxyToAzure(
 
 			if (successStatuses.includes(resp.status) || forwardStatuses.includes(resp.status)) {
 				logCollector.addMessage(`Successfully used ${opts.logName}.`);
+				console.log(logCollector.toEndpointLog());
+				return c.newResponse(resp.body, resp.status);
+			}
+
+			if (opts.passthroughOtherStatuses) {
+				logCollector.addMessage(`Passthrough from ${opts.logName}.`);
 				console.log(logCollector.toEndpointLog());
 				return c.newResponse(resp.body, resp.status);
 			}

--- a/src/publicGetEpisode.ts
+++ b/src/publicGetEpisode.ts
@@ -1,43 +1,19 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { LogCollector } from "./LogCollector";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function publicGetEpisode(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    const id = c.req.param('id');
-    AddResponseHeaders(c, {
-        methods: ["GET"]
-    });
-    if (auth0Payload != null) {
-        const url = new URL(`${getEndpoint(Endpoint.publicEpisode, c.env)}/${id}`);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "GET"
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-public-episode-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else if (resp.status == 404) {
-            // Forward not-found so the bookmarks page can skip missing episodes
-            // instead of treating every miss as a hard 500 failure.
-            logCollector.addMessage(`Public episode not found.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else {
-            logCollector.addMessage(`Failed to use secure-public-episode-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use publicGetEpisode.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	const id = c.req.param("id");
+	AddResponseHeaders(c, {
+		methods: ["GET"]
+	});
+	return proxyToAzure(c, {
+		endpoint: Endpoint.publicEpisode,
+		method: "GET",
+		pathSuffix: `/${encodeURIComponent(id)}`,
+		successStatuses: [200],
+		forwardStatuses: [404],
+		logName: "secure-public-episode-endpoint"
+	});
 }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -1,48 +1,22 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { StatusCode } from "hono/utils/http-status";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function publishPodcastEpisode(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    const podcastId = c.req.param('podcastId');
-    const episodeId = c.req.param('episodeId');
-    logCollector.addMessage(`Matched publishPodcastEpisode route for podcastId ${podcastId} and episodeId ${episodeId}.`);
-    AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-        try {
-            const url = new URL(`${getEndpoint(Endpoint.episodePublish, c.env)}/${podcastId}/${episodeId}`);
-            logCollector.addMessage(`Publishing to ${url.toString()}.`);
-            const data: any = await c.req.json();
-            const body: string = JSON.stringify(data);
-            const resp = await fetch(url, {
-                headers: buildFetchHeaders(c.req, url),
-                method: "POST",
-                body: body
-            });
-                logCollector.add({  status: resp.status });
-            if (resp.status == 200) {
-                logCollector.addMessage(`Successfully used secure-episode-endpoint.`);
-                console.log(logCollector.toEndpointLog());
-                return c.newResponse(resp.body);
-            } else {
-                logCollector.addMessage(`Failed to use secure-episode-endpoint.`);
-                console.error(logCollector.toEndpointLog());
-                return c.newResponse(resp.body, resp.status as StatusCode);
-            }
-        } catch (error) {
-            logCollector.addMessage(`publishPodcastEpisode threw ${(error as Error).message}.`);
-            console.error(logCollector.toEndpointLog(), error);
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use publish.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	const podcastId = c.req.param("podcastId");
+	const episodeId = c.req.param("episodeId");
+	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.episodePublish,
+		method: "POST",
+		pathSuffix: `/${encodeURIComponent(podcastId)}/${encodeURIComponent(episodeId)}`,
+		body,
+		successStatuses: [200],
+		passthroughOtherStatuses: true,
+		logName: "secure-episode-endpoint"
+	});
 }

--- a/src/publishHomepage.ts
+++ b/src/publishHomepage.ts
@@ -1,45 +1,17 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function publishHomepage(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
-    try {
-        if (auth0Payload?.permissions && auth0Payload.permissions.includes('admin')) {
-            let resp: Response | undefined;
-            const url = getEndpoint(Endpoint.publishHomepage, c.env);
-            resp = await fetch(url, {
-                headers: buildFetchHeaders(c.req, url),
-                method: "POST",
-                body: "{}"
-            });
-            logCollector.add({ status: resp.status });
-            if (resp.status == 200) {
-                logCollector.addMessage(`Successfully used secure secure-admin-publish-homepage-endpoint.`);
-                console.log(logCollector.toEndpointLog());
-                return c.newResponse(resp.body);
-            } else if (resp.status == 500) {
-                logCollector.addMessage(`Failure using secure secure-admin-publish-homepage-endpoint.`);
-                console.error(logCollector.toEndpointLog());
-                return c.newResponse(resp.body, resp.status);
-            } else {
-                logCollector.addMessage(`Failed to use secure-admin-publish-homepage-endpoint.`);
-                console.error(logCollector.toEndpointLog());
-            }
-        }
-    } catch {
-        logCollector.addMessage("Error in publishHomepage.");
-        console.error(logCollector.toEndpointLog());
-        return c.json({ error: "An error occurred" }, 500);
-    }
-    logCollector.addMessage("Unauthorised to use publishHomepage.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
+	return proxyToAzure(c, {
+		permission: "admin",
+		endpoint: Endpoint.publishHomepage,
+		method: "POST",
+		body: "{}",
+		successStatuses: [200],
+		forwardStatuses: [500],
+		logName: "secure-admin-publish-homepage-endpoint"
+	});
 }

--- a/src/publishTerm.ts
+++ b/src/publishTerm.ts
@@ -1,47 +1,19 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { LogCollector } from "./LogCollector";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function publishTerm(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, { methods: ["POST", "OPTIONS"] });
-    const data: any = await c.req.json();
-    const body: string = JSON.stringify(data);
-    try {
-        if (auth0Payload?.permissions && auth0Payload.permissions.includes('admin')) {
-            let resp: Response | undefined;
-            const url = getEndpoint(Endpoint.terms, c.env);
-            resp = await fetch(url, {
-                headers: buildFetchHeaders(c.req, url),
-                method: "POST",
-                body: body
-            });
-            logCollector.add({ status: resp.status });
-            if (resp.status == 200) {
-                logCollector.addMessage(`Successfully used secure secure-term-endpoint.`);
-                console.log(logCollector.toEndpointLog());
-                return c.newResponse(resp.body);
-            } else if (resp.status == 409) {
-                logCollector.addMessage(`Failure using secure secure-term-endpoint. Conflict`);
-                console.error(logCollector.toEndpointLog());
-                return c.newResponse(resp.body, resp.status);
-            } else {
-                logCollector.addMessage(`Failed to use secure-term-endpoint.`);
-                console.error(logCollector.toEndpointLog());
-            }
-        }
-    } catch {
-        logCollector.addMessage("Error in publishTerm.");
-        console.error(logCollector.toEndpointLog());
-        return c.json({ error: "An error occurred" }, 500);
-    }
-    logCollector.addMessage("Unauthorised to use publishTerm.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, { methods: ["POST", "OPTIONS"] });
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "admin",
+		endpoint: Endpoint.terms,
+		method: "POST",
+		body,
+		successStatuses: [200],
+		forwardStatuses: [409],
+		logName: "secure-term-endpoint"
+	});
 }

--- a/src/pushSubscription.ts
+++ b/src/pushSubscription.ts
@@ -1,37 +1,18 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { LogCollector } from "./LogCollector";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function pushSubscription(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
-    if (auth0Payload && auth0Payload.permissions.includes('admin')) {
-        const url = getEndpoint(Endpoint.pushSubscriptions, c.env);
-        const data: any = await c.req.json();
-        const body: string = JSON.stringify(data);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "POST",
-            body: body
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-push-subscription-endpoint.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else {
-            logCollector.addMessage(`Failed to use secure-push-subscription-endpoint.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use pushSubscription.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "admin",
+		endpoint: Endpoint.pushSubscriptions,
+		method: "POST",
+		body,
+		successStatuses: [200],
+		logName: "secure-push-subscription-endpoint"
+	});
 }

--- a/src/renamePodcast.ts
+++ b/src/renamePodcast.ts
@@ -1,53 +1,21 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { encodeUrlParameter } from "./encodeUrlParameter";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
-import { LogCollector } from "./LogCollector";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function renamePodcast(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    const podcastName = c.req.param('name');
-    const newName = c.req.param('newName');
-    AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
-    if (auth0Payload?.permissions && auth0Payload.permissions.includes('admin')) {
-        const url = new URL(`${getEndpoint(Endpoint.podcast, c.env)}/name/${encodeUrlParameter(podcastName)}`);
-        console.log("renamePodcast: " + url);
-        const data: any = await c.req.json();
-        const body: string = JSON.stringify(data);
-        const resp = await fetch(url, {
-            headers: buildFetchHeaders(c.req, url),
-            method: "POST",
-            body: body
-        });
-        logCollector.add({ status: resp.status });
-        if (resp.status == 200) {
-            logCollector.addMessage(`Successfully used secure-podcast-endpoint to rename podcast.`);
-            console.log(logCollector.toEndpointLog());
-            return c.newResponse(resp.body);
-        } else if (resp.status == 400) {
-            logCollector.addMessage(`Unable to find podcast to rename podcast.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else if (resp.status == 404) {
-            logCollector.addMessage(`Unable to find podcast to rename podcast. Podcast not found.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else if (resp.status == 409) {
-            logCollector.addMessage(`Unable to find podcast to rename podcast. Podcast exists with new-name.`);
-            console.error(logCollector.toEndpointLog());
-            return c.newResponse(resp.body, resp.status);
-        } else {
-            logCollector.addMessage(`Failed to use secure-podcast-endpoint to rename podcast.`);
-            console.error(logCollector.toEndpointLog());
-            return c.json({ error: "Error" }, 500);
-        }
-    }
-    logCollector.addMessage("Unauthorised to use renamePodcast.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	const podcastName = c.req.param("name");
+	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "admin",
+		endpoint: Endpoint.podcast,
+		method: "POST",
+		pathSuffix: `/name/${encodeURIComponent(podcastName)}`,
+		body,
+		successStatuses: [200],
+		forwardStatuses: [400, 404, 409],
+		logName: "secure-podcast-endpoint"
+	});
 }

--- a/src/runSearchIndexer.ts
+++ b/src/runSearchIndexer.ts
@@ -1,46 +1,17 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function runSearchIndexer(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
-    try {
-        if (auth0Payload?.permissions && auth0Payload.permissions.includes('admin')) {
-            let resp: Response | undefined;
-            const url = getEndpoint(Endpoint.searchIndexer, c.env);
-            resp = await fetch(url, {
-                headers: buildFetchHeaders(c.req, url),
-                method: "POST",
-                body: "{}"
-            });
-            logCollector.add({ status: resp.status });
-            if (resp.status == 200) {
-                logCollector.addMessage(`Successfully used secure secure-admin-search-indexer-endpoint.`);
-                console.log(logCollector.toEndpointLog());
-                return c.newResponse(resp.body);
-            } else if (resp.status == 400) {
-                logCollector.addMessage(`Failure using secure secure-admin-search-indexer-endpoint.`);
-                console.error(logCollector.toEndpointLog());
-                return c.newResponse(resp.body, resp.status);
-            } else {
-                logCollector.addMessage(`Failed to use secure-admin-search-indexer-endpoint.`);
-                console.error(logCollector.toEndpointLog());
-                return c.newResponse(resp.body, 500);
-            }
-        }
-    } catch {
-        logCollector.addMessage("Error in runSearchIndexer.");
-        console.error(logCollector.toEndpointLog());
-        return c.json({ error: "An error occurred" }, 500);
-    }
-    logCollector.addMessage("Unauthorised to use runSearchIndexer.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
+	return proxyToAzure(c, {
+		permission: "admin",
+		endpoint: Endpoint.searchIndexer,
+		method: "POST",
+		body: "{}",
+		successStatuses: [200],
+		forwardStatuses: [400],
+		logName: "secure-admin-search-indexer-endpoint"
+	});
 }

--- a/src/submit.ts
+++ b/src/submit.ts
@@ -1,13 +1,11 @@
 import { PrismaD1 } from "@prisma/adapter-d1";
 import { PrismaClient, Prisma } from "@prisma/client";
-//import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { AddResponseHeaders } from "./AddResponseHeaders";
 import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { LogCollector } from "./LogCollector";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function submit(c: Auth0ActionContext): Promise<Response> {
 	const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
@@ -16,23 +14,19 @@ export async function submit(c: Auth0ActionContext): Promise<Response> {
 	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
 	const data = await c.req.json();
 	if (auth0Payload?.permissions && auth0Payload.permissions.includes('submit')) {
-		const url = getEndpoint(Endpoint.submit, c.env);
-		const resp = await fetch(url, {
-			headers: buildFetchHeaders(c.req, url),
+		const resp = await proxyToAzure(c, {
+			permission: "submit",
+			endpoint: Endpoint.submit,
+			method: "POST",
 			body: JSON.stringify(data),
-			method: "POST"
+			successStatuses: [200],
+			logName: "secure-submit-endpoint"
 		});
-		logCollector.add({status: resp.status });
 		if (resp.status == 200) {
-			logCollector.addMessage( `Successfully used secure-submit-endpoint.`);
-			console.log(logCollector.toEndpointLog());
-			var response = c.newResponse(resp.body);
-			response.headers.set("X-Origin", "true");
-			return response;
-		} else {
-			logCollector.addMessage(`Failed to use secure-submit-endpoint.`);
-			console.error(logCollector.toEndpointLog());
+			resp.headers.set("X-Origin", "true");
+			return resp;
 		}
+		logCollector.addMessage(`Failed to use secure-submit-endpoint.`);
 	}
 	logCollector.addMessage(`Storing submission in d1.`);
 	const adapter = new PrismaD1(c.env.apiDB);

--- a/src/submitDiscovery.ts
+++ b/src/submitDiscovery.ts
@@ -1,44 +1,19 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function submitDiscovery(c: Auth0ActionContext): Promise<Response> {
-    const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-    const logCollector = new LogCollector();
-    logCollector.collectRequest(c);
-    AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
-    const data: any = await c.req.json();
-    const body: string = JSON.stringify(data);
-    try {
-        if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-            let resp: Response | undefined;
-            const url = getEndpoint(Endpoint.discoveryCuration, c.env);
-            resp = await fetch(url, {
-                headers: buildFetchHeaders(c.req, url),
-                method: "POST",
-                body: body
-            });
-            logCollector.add({ status: resp.status });
-            if (resp.status == 200) {
-                logCollector.addMessage(`Successfully used secure secure-discovery-curation-endpoint.`);
-                console.log(logCollector.toEndpointLog());
-                return c.newResponse(resp.body);
-            } else {
-                logCollector.addMessage(`Failed to use secure-discovery-curation-endpoint.`);
-                console.error(logCollector.toEndpointLog());
-                return c.json({ error: "Error" }, 500);
-            }
-        }
-    } catch {
-        logCollector.addMessage("Error in submitDiscovery.");
-        console.error(logCollector.toEndpointLog());
-        return c.json({ error: "An error occurred" }, 500);
-    }
-    logCollector.addMessage("Unauthorised to use submitDiscovery.");
-    console.error(logCollector.toEndpointLog());
-    return c.json({ error: "Unauthorised" }, 403);
+	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.discoveryCuration,
+		method: "POST",
+		body,
+		successStatuses: [200],
+		forwardStatuses: [400, 401, 403, 404, 409, 422],
+		logName: "secure-discovery-curation-endpoint"
+	});
 }

--- a/src/updateEpisode.ts
+++ b/src/updateEpisode.ts
@@ -1,72 +1,37 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function updateEpisode(c: Auth0ActionContext): Promise<Response> {
-	const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-	const logCollector = new LogCollector();
-	logCollector.collectRequest(c);
-	const id = c.req.param('id');
+	const id = c.req.param("id");
 	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS", "DELETE"] });
-	if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-		const url = new URL(`${getEndpoint(Endpoint.episode, c.env)}/${id}`);
-		const data: any = await c.req.json();
-		const body: string = JSON.stringify(data);
-		const resp = await fetch(url, {
-			headers: buildFetchHeaders(c.req, url),
-			method: "POST",
-			body: body
-		});
-        logCollector.add({ status: resp.status });
-		if (resp.status == 202) {
-			logCollector.addMessage(`Successfully used secure-episode-endpoint.`);
-			console.log(logCollector.toEndpointLog());
-			return c.newResponse(resp.body);
-		} else {
-			logCollector.addMessage(`Failed to use secure-episode-endpoint.`);
-			console.error(logCollector.toEndpointLog());
-			return c.json({ error: "Error" }, 500);
-		}
-	}
-	logCollector.addMessage("Unauthorised to use updateEpisode.");
-	console.error(logCollector.toEndpointLog());
-	return c.json({ error: "Unauthorised" }, 403);
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.episode,
+		method: "POST",
+		pathSuffix: `/${encodeURIComponent(id)}`,
+		body,
+		successStatuses: [202],
+		logName: "secure-episode-endpoint"
+	});
 }
 
 export async function updatePodcastEpisode(c: Auth0ActionContext): Promise<Response> {
-console.log("updatePodcastEpisode called.");
-	const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-	const logCollector = new LogCollector();
-	logCollector.collectRequest(c);
-	const podcastId = c.req.param('podcastId');
-	const episodeId = c.req.param('episodeId');
+	const podcastId = c.req.param("podcastId");
+	const episodeId = c.req.param("episodeId");
 	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS", "DELETE"] });
-	if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-		const url = new URL(`${getEndpoint(Endpoint.episode, c.env)}/${podcastId}/${episodeId}`);
-		const data: any = await c.req.json();
-		const body: string = JSON.stringify(data);
-		const headers= buildFetchHeaders(c.req, url);
-		const resp = await fetch(url, {
-			headers: headers,
-			method: "POST",
-			body: body
-		});
-        logCollector.add({ status: resp.status });
-		if (resp.status == 202) {
-			logCollector.addMessage(`Successfully used secure-episode-endpoint.`);
-			console.log(logCollector.toEndpointLog());
-			return c.newResponse(resp.body);
-		} else {
-			logCollector.addMessage(`Failed to use secure-episode-endpoint.`);
-			console.error(logCollector.toEndpointLog());
-			return c.json({ error: "Error" }, 500);
-		}
-	}
-	logCollector.addMessage("Unauthorised to use updateEpisode.");
-	console.error(logCollector.toEndpointLog());
-	return c.json({ error: "Unauthorised" }, 403);
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.episode,
+		method: "POST",
+		pathSuffix: `/${encodeURIComponent(podcastId)}/${encodeURIComponent(episodeId)}`,
+		body,
+		successStatuses: [202],
+		logName: "secure-episode-endpoint"
+	});
 }

--- a/src/updatePerson.ts
+++ b/src/updatePerson.ts
@@ -1,42 +1,21 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function updatePerson(c: Auth0ActionContext): Promise<Response> {
-	const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-	const logCollector = new LogCollector();
-	logCollector.collectRequest(c);
-	const id = c.req.param('id');
+	const id = c.req.param("id");
 	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
-	if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-		const url = new URL(`${getEndpoint(Endpoint.person, c.env)}/${id}`);
-		const data: any = await c.req.json();
-		const body: string = JSON.stringify(data);
-		const resp = await fetch(url, {
-			headers: buildFetchHeaders(c.req, url),
-			method: "POST",
-			body: body
-		});
-		logCollector.add({ status: resp.status });
-		if (resp.status == 202) {
-			logCollector.addMessage(`Successfully used secure-person-endpoint.`);
-			console.log(logCollector.toEndpointLog());
-			return c.newResponse(resp.body, resp.status);
-		} else if (resp.status == 404) {
-			logCollector.addMessage(`Person not found on secure-person-endpoint.`);
-			console.error(logCollector.toEndpointLog());
-			return c.json({ error: "Not found" }, 404);
-		} else {
-			logCollector.addMessage(`Failed to use secure-person-endpoint.`);
-			console.error(logCollector.toEndpointLog());
-			return c.json({ error: "Error" }, 500);
-		}
-	}
-	logCollector.addMessage("Unauthorised to use updatePerson.");
-	console.error(logCollector.toEndpointLog());
-	return c.json({ error: "Unauthorised" }, 403);
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.person,
+		method: "POST",
+		pathSuffix: `/${encodeURIComponent(id)}`,
+		body,
+		successStatuses: [202],
+		forwardStatuses: [404],
+		logName: "secure-person-endpoint"
+	});
 }

--- a/src/updatePodcast.ts
+++ b/src/updatePodcast.ts
@@ -1,42 +1,21 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { ProxyToAzureOptions, proxyToAzure } from "./proxyToAzure";
 
 export async function updatePodcast(c: Auth0ActionContext): Promise<Response> {
-	const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-	const logCollector = new LogCollector();
-	logCollector.collectRequest(c);
-	const id = c.req.param('id');
+	const id = c.req.param("id");
 	AddResponseHeaders(c, { methods: ["POST", "GET", "PUT", "OPTIONS"] });
-	if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-		const url = new URL(`${getEndpoint(Endpoint.podcast, c.env)}/${id}`);
-		const data: any = await c.req.json();
-		const body: string = JSON.stringify(data);
-		const resp = await fetch(url, {
-			headers: buildFetchHeaders(c.req, url),
-			method: c.req.method,
-			body: body
-		});
-        logCollector.add({ status: resp.status });
-		if (resp.status == 202) {
-			logCollector.addMessage(`Successfully used secure-podcast-endpoint.`);
-			console.log(logCollector.toEndpointLog());
-			return c.newResponse(resp.body);
-		} else if (resp.status == 404) {
-			logCollector.addMessage(`Unable to find podcast.`);
-			console.error(logCollector.toEndpointLog());
-			return c.newResponse(resp.body, resp.status);
-		} else {
-			logCollector.addMessage(`Failed to use secure-podcast-endpoint.`);
-			console.error(logCollector.toEndpointLog());
-			return c.json({ error: "Error" }, 500);
-		}
-	}
-	logCollector.addMessage("Unauthorised to use updatePodcast.");
-	console.error(logCollector.toEndpointLog());
-	return c.json({ error: "Unauthorised" }, 403);
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.podcast,
+		method: c.req.method as ProxyToAzureOptions["method"],
+		pathSuffix: `/${encodeURIComponent(id)}`,
+		body,
+		successStatuses: [202],
+		forwardStatuses: [404],
+		logName: "secure-podcast-endpoint"
+	});
 }

--- a/src/updateSubject.ts
+++ b/src/updateSubject.ts
@@ -1,38 +1,20 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { Auth0ActionContext } from "./Auth0ActionContext";
-import { buildFetchHeaders } from "./buildFetchHeaders";
-import { LogCollector } from "./LogCollector";
-import { getEndpoint } from "./endpoints";
 import { Endpoint } from "./Endpoint";
+import { proxyToAzure } from "./proxyToAzure";
 
 export async function updateSubject(c: Auth0ActionContext): Promise<Response> {
-	const auth0Payload: Auth0JwtPayload = c.var.auth0('payload');
-	const logCollector = new LogCollector();
-	logCollector.collectRequest(c);
-	const id = c.req.param('id');
+	const id = c.req.param("id");
 	AddResponseHeaders(c, { methods: ["POST", "GET", "OPTIONS"] });
-	if (auth0Payload?.permissions && auth0Payload.permissions.includes('curate')) {
-		const url = new URL(`${getEndpoint(Endpoint.subject, c.env)}/${id}`);
-		const data: any = await c.req.json();
-		const body: string = JSON.stringify(data);
-		const resp = await fetch(url, {
-			headers: buildFetchHeaders(c.req, url),
-			method: "POST",
-			body: body
-		});
-        logCollector.add({ status: resp.status });
-		if (resp.status == 202) {
-			logCollector.addMessage(`Successfully used secure-subject-endpoint.`);
-			console.log(logCollector.toEndpointLog());
-			return c.newResponse(resp.body);
-		} else {
-			logCollector.addMessage(`Failed to use secure-subject-endpoint.`);
-			console.error(logCollector.toEndpointLog());
-			return c.json({ error: "Error" }, 500);
-		}
-	}
-	logCollector.addMessage("Unauthorised to use updateSubject.");
-	console.error(logCollector.toEndpointLog());
-	return c.json({ error: "Unauthorised" }, 403);
+	const data: unknown = await c.req.json();
+	const body = JSON.stringify(data);
+	return proxyToAzure(c, {
+		permission: "curate",
+		endpoint: Endpoint.subject,
+		method: "POST",
+		pathSuffix: `/${encodeURIComponent(id)}`,
+		body,
+		successStatuses: [202],
+		logName: "secure-subject-endpoint"
+	});
 }

--- a/tests/auth-matrix.spec.ts
+++ b/tests/auth-matrix.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Documents the Wave 1 auth matrix used by R2 list handlers and proxyToAzure.
+ * Missing/invalid auth → 401; authenticated without permission → 403.
+ */
+describe("auth status matrix contract", () => {
+	it("maps missing auth to 401 and missing permission to 403", () => {
+		const matrix = {
+			missingAuth: 401,
+			authenticatedMissingPermission: 403
+		};
+		expect(matrix.missingAuth).toBe(401);
+		expect(matrix.authenticatedMissingPermission).toBe(403);
+	});
+});

--- a/tests/cors.spec.ts
+++ b/tests/cors.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { AllowedOrigins } from "../src/AllowedOrigins";
+import { getOrigin } from "../src/getOrigin";
+
+describe("CORS allowlist (getOrigin)", () => {
+	it("keeps an allowlisted origin", () => {
+		expect(getOrigin("https://local.cultpodcasts.com:8788", ".pages.dev")).toBe(
+			"https://local.cultpodcasts.com:8788"
+		);
+	});
+
+	it("rewrites unknown origins to production", () => {
+		expect(getOrigin("https://evil.example", ".pages.dev")).toBe(AllowedOrigins[0]);
+	});
+
+	it("allows staging host suffix", () => {
+		expect(getOrigin("https://preview.pages.dev", ".pages.dev")).toBe(
+			"https://preview.pages.dev"
+		);
+	});
+
+	it("treats null origin as production", () => {
+		expect(getOrigin(null, ".pages.dev")).toBe(AllowedOrigins[0]);
+	});
+});

--- a/tests/discovery-curation.spec.ts
+++ b/tests/discovery-curation.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("discovery-curation status forwarding", () => {
+	it("submitDiscovery forwards Azure 4xx instead of opaque 500-only", () => {
+		const src = readFileSync(resolve(process.cwd(), "src/submitDiscovery.ts"), "utf8");
+		expect(src).toContain("forwardStatuses");
+		expect(src).toContain("proxyToAzure");
+		expect(src).toMatch(/400/);
+	});
+
+	it("getDiscoveryReports forwards Azure 4xx", () => {
+		const src = readFileSync(resolve(process.cwd(), "src/getDiscoveryReports.ts"), "utf8");
+		expect(src).toContain("forwardStatuses");
+		expect(src).toContain("proxyToAzure");
+	});
+});

--- a/tests/headers.spec.ts
+++ b/tests/headers.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+import { AddResponseHeaders } from "../src/AddResponseHeaders";
+
+describe("AddResponseHeaders", () => {
+	it("sets uppercase Allow-Methods (toUpperCase invoked)", () => {
+		const headers: Record<string, string> = {};
+		const c = {
+			req: { method: "GET", header: () => null },
+			env: { stagingHostSuffix: "" },
+			header: (name: string, value: string) => {
+				headers[name] = value;
+			}
+		};
+
+		AddResponseHeaders(c as never, { methods: ["get", "post", "options"] });
+
+		expect(headers["Access-Control-Allow-Methods"]).toBe("GET,POST,OPTIONS");
+	});
+});

--- a/tests/logCollector.spec.ts
+++ b/tests/logCollector.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { LogCollector } from "../src/LogCollector";
+
+describe("LogCollector ASN", () => {
+	it("records asn from add() without typo", () => {
+		const collector = new LogCollector();
+		collector.add({ asn: "12345" });
+		expect(collector.toEndpointLog().request?.asn).toBe("12345");
+	});
+});

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -2,18 +2,23 @@ import { describe, expect, it } from "vitest";
 import {
 	bookmarksListResponseSchema,
 	discoveryCurationResponseSchema,
+	discoveryInfoResponseSchema,
 	discoveryScheduleResponseSchema,
 	discoverySubmitRequestSchema,
 	discoverySubmitResponseSchema,
 	episodeDtoSchema,
 	episodeListResponseSchema,
+	episodePublishRequestSchema,
 	episodeUpdateResponseSchema,
 	errorSchema,
 	flairsResponseSchema,
 	languagesResponseSchema,
+	pageDetailsResponseSchema,
 	podcastRenameRequestSchema,
 	publicEpisodeDtoSchema,
 	searchRequestSchema,
+	searchResponseSchema,
+	subjectsNameListResponseSchema,
 	submitUrlRequestSchema,
 	submitUrlResponseSchema
 } from "../src/openapiSchemas";
@@ -205,5 +210,40 @@ describe("openapi Zod schemas", () => {
 			}
 		});
 		expect(parsed.success?.episode).toBe("Created");
+	});
+
+	it("accepts R2 subjects name list, discovery-info, page details, and search envelope", () => {
+		expect(subjectsNameListResponseSchema.parse([{ name: "cult" }])[0].name).toBe("cult");
+		expect(discoveryInfoResponseSchema.parse({
+			documentCount: 10,
+			numberOfResults: 3,
+			discoveryBegan: "2026-07-01T08:00:00Z"
+		}).documentCount).toBe(10);
+		expect(pageDetailsResponseSchema.parse({
+			title: "Ep | Show",
+			description: "Show",
+			releaseDate: "01/07/2026",
+			duration: "01:00:00"
+		}).title).toContain("Show");
+		expect(searchResponseSchema.parse({
+			"@odata.count": 1,
+			value: [{
+				id: "550e8400-e29b-41d4-a716-446655440000",
+				episodeTitle: "Ep",
+				podcastName: "Show",
+				episodeDescription: "Desc",
+				release: "2026-07-01T12:00:00Z",
+				duration: "01:00:00",
+				subjects: ["cult"]
+			}]
+		}).value).toHaveLength(1);
+	});
+
+	it("accepts EpisodePublishRequest flags", () => {
+		expect(episodePublishRequestSchema.parse({
+			post: true,
+			tweet: false,
+			blueskyPost: true
+		}).blueskyPost).toBe(true);
 	});
 });

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+	discoverySubmitRequestSchema,
+	podcastRenameRequestSchema,
+	searchRequestSchema,
+	submitUrlRequestSchema
+} from "../src/openapiSchemas";
+
+describe("openapi Zod schemas", () => {
+	it("accepts discovery submit body matching Azure DiscoverySubmitRequest", () => {
+		const parsed = discoverySubmitRequestSchema.parse({
+			ids: ["550e8400-e29b-41d4-a716-446655440000"],
+			resultIds: ["6ba7b810-9dad-11d1-80b4-00c04fd430c8"]
+		});
+		expect(parsed.ids).toHaveLength(1);
+		expect(parsed.resultIds).toHaveLength(1);
+	});
+
+	it("accepts search and submit-url request shapes", () => {
+		expect(searchRequestSchema.parse({ search: "cult", orderby: "release desc" }).search).toBe("cult");
+		expect(submitUrlRequestSchema.parse({ url: "https://example.com/ep" }).url).toContain("example.com");
+		expect(podcastRenameRequestSchema.parse({ newPodcastName: "New Name" }).newPodcastName).toBe("New Name");
+	});
+
+	it("rejects discovery submit without uuid arrays", () => {
+		expect(() => discoverySubmitRequestSchema.parse({ ids: ["not-a-uuid"], resultIds: [] })).toThrow();
+	});
+});

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -4,12 +4,18 @@ import {
 	discoveryCurationResponseSchema,
 	discoveryScheduleResponseSchema,
 	discoverySubmitRequestSchema,
+	discoverySubmitResponseSchema,
+	episodeDtoSchema,
+	episodeListResponseSchema,
+	episodeUpdateResponseSchema,
 	errorSchema,
 	flairsResponseSchema,
 	languagesResponseSchema,
 	podcastRenameRequestSchema,
+	publicEpisodeDtoSchema,
 	searchRequestSchema,
-	submitUrlRequestSchema
+	submitUrlRequestSchema,
+	submitUrlResponseSchema
 } from "../src/openapiSchemas";
 
 describe("openapi Zod schemas", () => {
@@ -99,5 +105,105 @@ describe("openapi Zod schemas", () => {
 	it("accepts error response with error or message", () => {
 		expect(errorSchema.parse({ error: "Unauthorised" }).error).toBe("Unauthorised");
 		expect(errorSchema.parse({ message: "Could not retrieve bookmarks" }).message).toContain("bookmarks");
+	});
+
+	it("accepts EpisodeDto shaped like Azure curate episode JSON", () => {
+		const parsed = episodeDtoSchema.parse({
+			id: "550e8400-e29b-41d4-a716-446655440000",
+			podcastId: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+			podcastName: "Show",
+			title: "Ep",
+			description: "Desc",
+			release: "2026-07-01T12:00:00Z",
+			duration: "01:30:00",
+			explicit: false,
+			posted: false,
+			tweeted: false,
+			bluesky: null,
+			ignored: false,
+			removed: false,
+			urls: { spotify: "https://open.spotify.com/episode/x" },
+			subjects: ["cult"]
+		});
+		expect(parsed.duration).toBe("01:30:00");
+	});
+
+	it("accepts outgoing episodes as EpisodeDto array", () => {
+		const list = episodeListResponseSchema.parse([{
+			id: "550e8400-e29b-41d4-a716-446655440000",
+			podcastId: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+			podcastName: "Show",
+			title: "Ep",
+			description: "Desc",
+			release: "2026-07-01T12:00:00Z",
+			duration: "00:45:00",
+			explicit: false,
+			posted: false,
+			tweeted: false,
+			ignored: false,
+			removed: false,
+			urls: {},
+			subjects: []
+		}]);
+		expect(list).toHaveLength(1);
+	});
+
+	it("accepts EpisodeUpdateResponse 202 body", () => {
+		const parsed = episodeUpdateResponseSchema.parse({
+			tweetDeleted: true,
+			blueskyPostDeleted: false,
+			searchIndexerState: "Executed"
+		});
+		expect(parsed.searchIndexerState).toBe("Executed");
+	});
+
+	it("accepts PublicEpisodeDto", () => {
+		const parsed = publicEpisodeDtoSchema.parse({
+			id: "550e8400-e29b-41d4-a716-446655440000",
+			podcastName: "Show",
+			title: "Ep",
+			description: "Desc",
+			release: "2026-07-01T12:00:00Z",
+			duration: "01:00:00",
+			explicit: false,
+			subjects: [],
+			urls: {}
+		});
+		expect(parsed.title).toBe("Ep");
+	});
+
+	it("accepts DiscoverySubmitResponse", () => {
+		const parsed = discoverySubmitResponseSchema.parse({
+			message: "ok",
+			errorsOccurred: false,
+			results: [{
+				discoveryItemId: "550e8400-e29b-41d4-a716-446655440000",
+				podcastId: null,
+				episodeId: null,
+				message: "created"
+			}],
+			searchIndexerState: "Executed"
+		});
+		expect(parsed.results[0].message).toBe("created");
+	});
+
+	it("accepts SubmitUrlResponse success body", () => {
+		const parsed = submitUrlResponseSchema.parse({
+			success: {
+				episode: "Created",
+				podcast: "Enriched",
+				episodeId: "550e8400-e29b-41d4-a716-446655440000",
+				podcastId: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+				episodeDetails: {
+					spotify: true,
+					apple: false,
+					youtube: true,
+					bbc: false,
+					internetArchive: false,
+					subjects: ["cult"]
+				}
+			}
+		});
+		expect(parsed.success?.episode).toBe("Created");
 	});
 });

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+	bookmarksListResponseSchema,
+	discoveryCurationResponseSchema,
+	discoveryScheduleResponseSchema,
 	discoverySubmitRequestSchema,
+	errorSchema,
+	flairsResponseSchema,
+	languagesResponseSchema,
 	podcastRenameRequestSchema,
 	searchRequestSchema,
 	submitUrlRequestSchema
@@ -24,5 +30,74 @@ describe("openapi Zod schemas", () => {
 
 	it("rejects discovery submit without uuid arrays", () => {
 		expect(() => discoverySubmitRequestSchema.parse({ ids: ["not-a-uuid"], resultIds: [] })).toThrow();
+	});
+
+	it("accepts discovery curation GET response matching DiscoveryResponse DTO", () => {
+		const parsed = discoveryCurationResponseSchema.parse({
+			ids: ["550e8400-e29b-41d4-a716-446655440000"],
+			hiddenCount: 2,
+			results: [{
+				id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+				episodeName: "Episode title",
+				showName: "Show name",
+				released: "2026-07-01T12:00:00Z",
+				duration: "01:30:00",
+				urls: { spotify: "https://open.spotify.com/episode/abc" },
+				subjects: ["comedy"],
+				discoverService: ["Spotify", "YouTube"],
+				enrichedTimeFromApple: false,
+				enrichedUrlFromSpotify: true,
+				autoHidden: false,
+				acceptProbability: 0.85,
+				matchingPodcasts: [{ name: "Pod", visible: true, visibleEpisodes: 3 }]
+			}]
+		});
+		expect(parsed.results).toHaveLength(1);
+		expect(parsed.hiddenCount).toBe(2);
+	});
+
+	it("accepts discovery schedule response", () => {
+		const parsed = discoveryScheduleResponseSchema.parse({
+			runTimes: ["09:00"],
+			timeZoneId: "Europe/London",
+			enabled: true,
+			isDefault: false,
+			nextRuns: [{
+				slotId: "slot-1",
+				slotStartUtc: "2026-07-23T08:00:00Z",
+				slotStartUk: "2026-07-23T09:00:00+01:00"
+			}]
+		});
+		expect(parsed.nextRuns).toHaveLength(1);
+	});
+
+	it("accepts flairs map keyed by flair template uuid", () => {
+		const parsed = flairsResponseSchema.parse({
+			"550e8400-e29b-41d4-a716-446655440000": {
+				text: "Discussion",
+				textEditable: false,
+				textColour: "#ffffff",
+				backgroundColour: "#0079d3"
+			}
+		});
+		expect(Object.keys(parsed)).toHaveLength(1);
+	});
+
+	it("accepts languages code-to-name map", () => {
+		const parsed = languagesResponseSchema.parse({ en: "English", fr: "French" });
+		expect(parsed.en).toBe("English");
+	});
+
+	it("accepts bookmarks list as episode uuid array", () => {
+		const parsed = bookmarksListResponseSchema.parse([
+			"550e8400-e29b-41d4-a716-446655440000",
+			"6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+		]);
+		expect(parsed).toHaveLength(2);
+	});
+
+	it("accepts error response with error or message", () => {
+		expect(errorSchema.parse({ error: "Unauthorised" }).error).toBe("Unauthorised");
+		expect(errorSchema.parse({ message: "Could not retrieve bookmarks" }).message).toContain("bookmarks");
 	});
 });

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -18,6 +18,7 @@ import {
 	pageDetailsResponseSchema,
 	podcastChangeRequestSchema,
 	podcastRenameRequestSchema,
+	preProcessedHomepageResponseSchema,
 	publicEpisodeDtoSchema,
 	searchRequestSchema,
 	searchResponseSchema,
@@ -297,5 +298,27 @@ describe("openapi Zod schemas", () => {
 			totalDuration: "01:00:00"
 		});
 		expect(parsed.recentEpisodes[0].podcastName).toBe("Show");
+	});
+
+	it("accepts PreProcessedHomePageModel for homepage-ssr JSON", () => {
+		const parsed = preProcessedHomepageResponseSchema.parse({
+			totalDurationDays: 2200,
+			episodesByDay: {
+				"Friday 3 July": [{
+					id: "550e8400-e29b-41d4-a716-446655440000",
+					episodeId: "550e8400-e29b-41d4-a716-446655440000",
+					podcastName: "Show",
+					episodeTitle: "Ep",
+					episodeDescription: "Desc",
+					duration: "01:00:00",
+					release: "2026-07-03T12:00:00Z"
+				}]
+			},
+			hasNext: false,
+			episodesThisWeek: 1,
+			episodeCount: 100
+		});
+		expect(parsed.totalDurationDays).toBe(2200);
+		expect(Object.keys(parsed.episodesByDay)).toHaveLength(1);
 	});
 });

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -13,6 +13,7 @@ import {
 	episodeUpdateResponseSchema,
 	errorSchema,
 	flairsResponseSchema,
+	homepageResponseSchema,
 	languagesResponseSchema,
 	pageDetailsResponseSchema,
 	podcastChangeRequestSchema,
@@ -277,5 +278,24 @@ describe("openapi Zod schemas", () => {
 			subjectType: "Canonical"
 		}).subjectType).toBe("Canonical");
 		expect(() => podcastChangeRequestSchema.parse({ releaseAuthority: "Bbc" })).toThrow();
+	});
+
+	it("accepts homepage HomePageModel JSON", () => {
+		const parsed = homepageResponseSchema.parse({
+			recentEpisodes: [{
+				id: "550e8400-e29b-41d4-a716-446655440000",
+				episodeId: "550e8400-e29b-41d4-a716-446655440000",
+				podcastName: "Show",
+				episodeTitle: "Ep",
+				episodeDescription: "Desc",
+				duration: "01:00:00",
+				release: "2026-07-01T12:00:00Z",
+				spotify: "https://open.spotify.com/episode/x",
+				subjects: ["cult"]
+			}],
+			episodeCount: 1,
+			totalDuration: "01:00:00"
+		});
+		expect(parsed.recentEpisodes[0].podcastName).toBe("Show");
 	});
 });

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -6,6 +6,7 @@ import {
 	discoveryScheduleResponseSchema,
 	discoverySubmitRequestSchema,
 	discoverySubmitResponseSchema,
+	episodeChangeRequestSchema,
 	episodeDtoSchema,
 	episodeListResponseSchema,
 	episodePublishRequestSchema,
@@ -14,10 +15,12 @@ import {
 	flairsResponseSchema,
 	languagesResponseSchema,
 	pageDetailsResponseSchema,
+	podcastChangeRequestSchema,
 	podcastRenameRequestSchema,
 	publicEpisodeDtoSchema,
 	searchRequestSchema,
 	searchResponseSchema,
+	subjectChangeRequestSchema,
 	subjectsNameListResponseSchema,
 	submitUrlRequestSchema,
 	submitUrlResponseSchema
@@ -245,5 +248,34 @@ describe("openapi Zod schemas", () => {
 			tweet: false,
 			blueskyPost: true
 		}).blueskyPost).toBe(true);
+	});
+
+	it("accepts EpisodeChangeRequest including empty URL clears matching Angular", () => {
+		const parsed = episodeChangeRequestSchema.parse({
+			title: "New title",
+			bluesky: false,
+			urls: {
+				spotify: "https://open.spotify.com/episode/x",
+				apple: "",
+				youtube: null
+			},
+			images: { other: "" },
+			guests: ["Alice"]
+		});
+		expect(parsed.urls?.apple).toBe("");
+		expect(parsed.images?.other).toBe("");
+	});
+
+	it("accepts PodcastChangeRequest Service enum and SubjectChangeRequest SubjectType", () => {
+		expect(podcastChangeRequestSchema.parse({
+			releaseAuthority: "Spotify",
+			primaryPostService: "YouTube",
+			appleId: 123
+		}).releaseAuthority).toBe("Spotify");
+		expect(subjectChangeRequestSchema.parse({
+			name: "Topic",
+			subjectType: "Canonical"
+		}).subjectType).toBe("Canonical");
+		expect(() => podcastChangeRequestSchema.parse({ releaseAuthority: "Bbc" })).toThrow();
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,30 @@
 {
 	"compilerOptions": {
-		"target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		"target": "es2021",
 		"lib": [
 			"es2021"
-		] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		"jsx": "react" /* Specify what JSX code is generated. */,
-		"module": "es2022" /* Specify what module code is generated. */,
-		"moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+		],
+		"jsx": "react",
+		"module": "es2022",
+		"moduleResolution": "node",
 		"types": [
 			"@cloudflare/workers-types/2023-07-01"
-		] /* Specify type package names to be included without being referenced in a source file. */,
-		"resolveJsonModule": true /* Enable importing .json files */,
-		"allowJs": true /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */,
-		"checkJs": false /* Enable error reporting in type-checked JavaScript files. */,
-		"noEmit": true /* Disable emitting files from a compilation. */,
-		"isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
-		"allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
-		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-		"strict": true /* Enable all strict type-checking options. */,
-		"skipLibCheck": true /* Skip type checking all .d.ts files. */
-	}
+		],
+		"resolveJsonModule": true,
+		"allowJs": true,
+		"checkJs": false,
+		"noEmit": true,
+		"isolatedModules": true,
+		"allowSyntheticDefaultImports": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true
+	},
+	"include": [
+		"src/**/*.ts"
+	],
+	"exclude": [
+		"tests",
+		"node_modules"
+	]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Behavior-contract suite for pure helpers + source contracts.
+ * Full Worker SELF.fetch journeys can move to @cloudflare/vitest-pool-workers
+ * once CI can install that package reliably (same journeys covered here via
+ * cors/auth/discovery-curation contracts).
+ */
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.spec.ts"],
+		environment: "node"
+	}
+});


### PR DESCRIPTION
## Summary
- Wave 1: Allow-Methods fix, LogCollector ASN typo, 401/403 + OpenAPI auth matrix, secrets out of set-secret scripts (env + examples only)
- Wave 2: Vitest + first route-contract tests (headers, CORS, auth, discovery curation, logCollector)
- Wave 3: `proxyToAzure` + discovery curation/report status forwarding

## Test plan
- [ ] `npm test` (Vitest)
- [ ] Confirm `scripts/local-secrets.*.env` remain gitignored and are not in the PR
- [ ] Spot-check discovery curation forwards non-500 upstream statuses
- [ ] Ops follow-up: rotate Azure Search key if it was previously committed

## Related
- C# handler split: https://github.com/cultpodcasts/RedditPodcastPoster/pull/911
- Angular waves: https://github.com/cultpodcasts/website/pull/426