### PR TITLE
feat(openapi): document homepage episode language field

### DIFF
--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -590,7 +590,9 @@ export const homepageEpisodeSchema = z.object({
 	bbc: z.string().url().optional().nullable(),
 	internetArchive: z.string().url().optional().nullable(),
 	subjects: z.array(z.string()).optional().nullable(),
-	image: z.string().url().optional().nullable()
+	image: z.string().url().optional().nullable(),
+	/** IETF language tag; omitted/absent for English. */
+	language: z.string().optional().nullable()
 });
 
 export const homepageResponseSchema = z.object({

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -292,12 +292,31 @@ describe("openapi Zod schemas", () => {
 				duration: "01:00:00",
 				release: "2026-07-01T12:00:00Z",
 				spotify: "https://open.spotify.com/episode/x",
-				subjects: ["cult"]
+				subjects: ["cult"],
+				language: "fr-FR"
 			}],
 			episodeCount: 1,
 			totalDuration: "01:00:00"
 		});
 		expect(parsed.recentEpisodes[0].podcastName).toBe("Show");
+		expect(parsed.recentEpisodes[0].language).toBe("fr-FR");
+	});
+
+	it("accepts homepage episode JSON without language (English/omitted)", () => {
+		const parsed = homepageResponseSchema.parse({
+			recentEpisodes: [{
+				id: "550e8400-e29b-41d4-a716-446655440000",
+				episodeId: "550e8400-e29b-41d4-a716-446655440000",
+				podcastName: "Show",
+				episodeTitle: "Ep",
+				episodeDescription: "Desc",
+				duration: "01:00:00",
+				release: "2026-07-01T12:00:00Z"
+			}],
+			episodeCount: 1,
+			totalDuration: "01:00:00"
+		});
+		expect(parsed.recentEpisodes[0].language).toBeUndefined();
 	});
 
 	it("accepts PreProcessedHomePageModel for homepage-ssr JSON", () => {


### PR DESCRIPTION
## Summary
- RedditPodcastPoster now emits an optional non-English IETF `language` tag on homepage recent-episode JSON (`RecentEpisode`). See cultpodcasts/RedditPodcastPoster#916.
- Add `language` (optional string, IETF tag) to the shared `homepageEpisodeSchema` in `src/openapiSchemas.ts`, used by both the `/homepage` and `/homepage-ssr` (pre-processed) responses, so Swagger stays honest for API consumers.
- Cover the new field with Vitest parse cases (present + absent/English-omitted).

## Test plan
- [x] `npm test` — all schema tests pass (22/22)
- [x] `npm run lint` — clean