### PR TITLE
feat(api): hero curation endpoint backed by KV

### DIFF
--- a/src/Env.ts
+++ b/src/Env.ts
@@ -1,5 +1,6 @@
 export type Env = {
 	shortner: KVNamespace;
+	Curated: KVNamespace;
 	auth0Issuer: string;
 	auth0Audience: string;
 	auth0ClientId: string;

--- a/src/getOrigin.ts
+++ b/src/getOrigin.ts
@@ -1,10 +1,20 @@
 import { AllowedOrigins } from "./AllowedOrigins";
 
+/** `stagingHostSuffix` may be a single suffix or comma-separated (e.g. `website-83e.pages.dev,flix-ac4.pages.dev`). */
 export function getOrigin(origin: string | null | undefined, stagingHostSuffix: string) {
-	if (origin == null ||
-		(AllowedOrigins.indexOf(origin.toLowerCase()) == -1 &&
-			(stagingHostSuffix && !origin.endsWith(stagingHostSuffix)))) {
-		origin = AllowedOrigins[0];
+	if (origin == null) {
+		return AllowedOrigins[0];
 	}
-	return origin;
+	const lower = origin.toLowerCase();
+	if (AllowedOrigins.indexOf(lower) !== -1) {
+		return origin;
+	}
+	const suffixes = (stagingHostSuffix ?? "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+	if (suffixes.some((suffix) => lower.endsWith(suffix.toLowerCase()))) {
+		return origin;
+	}
+	return AllowedOrigins[0];
 }

--- a/src/heroCuration.ts
+++ b/src/heroCuration.ts
@@ -1,0 +1,111 @@
+import { AddResponseHeaders } from "./AddResponseHeaders";
+import { ActionContext } from "./ActionContext";
+import { Auth0ActionContext } from "./Auth0ActionContext";
+import { Auth0JwtPayload } from "./Auth0JwtPayload";
+import { LogCollector } from "./LogCollector";
+import { heroCurationUpdateRequestSchema } from "./openapiSchemas";
+
+const HERO_KV_KEY = "hero-episode-ids";
+const MAX_EPISODE_IDS = 50;
+
+type HeroCurationStored = {
+	episodeIds: string[];
+	updatedAt: string;
+};
+
+function dedupeAndCap(ids: string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const id of ids) {
+		if (seen.has(id)) {
+			continue;
+		}
+		seen.add(id);
+		result.push(id);
+		if (result.length >= MAX_EPISODE_IDS) {
+			break;
+		}
+	}
+	return result;
+}
+
+export async function getHeroCuration(c: ActionContext): Promise<Response> {
+	const logCollector = new LogCollector();
+	logCollector.collectRequest(c);
+	AddResponseHeaders(c, {
+		methods: ["GET", "PUT", "OPTIONS"],
+		cacheControlMaxAge: 60
+	});
+
+	let stored: HeroCurationStored | null = null;
+	try {
+		stored = await c.env.Curated.get(HERO_KV_KEY, "json");
+	} catch {
+		logCollector.addMessage("Unable to retrieve hero curation from KV");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Failed to load hero curation" }, 500);
+	}
+
+	if (!stored) {
+		logCollector.addMessage("Hero curation empty (no KV value).");
+		console.log(logCollector.toEndpointLog());
+		return c.json({ episodeIds: [], updatedAt: null }, 200);
+	}
+
+	logCollector.addMessage("Successfully obtained hero curation.");
+	console.log(logCollector.toEndpointLog());
+	return c.json({
+		episodeIds: Array.isArray(stored.episodeIds) ? stored.episodeIds : [],
+		updatedAt: stored.updatedAt ?? null
+	}, 200);
+}
+
+export async function putHeroCuration(c: Auth0ActionContext): Promise<Response> {
+	const auth0Payload: Auth0JwtPayload = c.var.auth0("payload");
+	const logCollector = new LogCollector();
+	logCollector.collectRequest(c);
+	AddResponseHeaders(c, { methods: ["GET", "PUT", "OPTIONS"] });
+
+	if (!auth0Payload) {
+		logCollector.addMessage("Unauthorised to use putHeroCuration.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Unauthorised" }, 401);
+	}
+	if (!auth0Payload.permissions?.includes("curate")) {
+		logCollector.addMessage("Forbidden to use putHeroCuration.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Forbidden" }, 403);
+	}
+
+	let body: unknown;
+	try {
+		body = await c.req.json();
+	} catch {
+		logCollector.addMessage("Invalid JSON body for putHeroCuration.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Bad request" }, 400);
+	}
+
+	const parsed = heroCurationUpdateRequestSchema.safeParse(body);
+	if (!parsed.success) {
+		logCollector.addMessage("Invalid hero curation body.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Bad request" }, 400);
+	}
+
+	const episodeIds = dedupeAndCap(parsed.data.episodeIds);
+	const updatedAt = new Date().toISOString();
+	const stored: HeroCurationStored = { episodeIds, updatedAt };
+
+	try {
+		await c.env.Curated.put(HERO_KV_KEY, JSON.stringify(stored));
+	} catch {
+		logCollector.addMessage("Unable to store hero curation in KV");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Failed to save hero curation" }, 500);
+	}
+
+	logCollector.addMessage(`Hero curation updated (${episodeIds.length} episodeIds).`);
+	console.log(logCollector.toEndpointLog());
+	return c.json(stored, 200);
+}

--- a/src/heroCuration.ts
+++ b/src/heroCuration.ts
@@ -7,26 +7,44 @@ import { heroCurationUpdateRequestSchema } from "./openapiSchemas";
 
 const HERO_KV_KEY = "hero-episode-ids";
 const MAX_EPISODE_IDS = 50;
+const MAX_RAIL_SUBJECTS = 12;
 
 type HeroCurationStored = {
 	episodeIds: string[];
+	railSubjects: string[];
 	updatedAt: string;
 };
 
-function dedupeAndCap(ids: string[]): string[] {
+function dedupeAndCap(values: string[], max: number): string[] {
 	const seen = new Set<string>();
 	const result: string[] = [];
-	for (const id of ids) {
-		if (seen.has(id)) {
+	for (const value of values) {
+		if (seen.has(value)) {
 			continue;
 		}
-		seen.add(id);
-		result.push(id);
-		if (result.length >= MAX_EPISODE_IDS) {
+		seen.add(value);
+		result.push(value);
+		if (result.length >= max) {
 			break;
 		}
 	}
 	return result;
+}
+
+function storedList(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+async function readStored(kv: KVNamespace): Promise<HeroCurationStored | null> {
+	const stored = await kv.get<Partial<HeroCurationStored>>(HERO_KV_KEY, "json");
+	if (!stored) {
+		return null;
+	}
+	return {
+		episodeIds: storedList(stored.episodeIds),
+		railSubjects: storedList(stored.railSubjects),
+		updatedAt: stored.updatedAt ?? new Date(0).toISOString()
+	};
 }
 
 export async function getHeroCuration(c: ActionContext): Promise<Response> {
@@ -39,7 +57,7 @@ export async function getHeroCuration(c: ActionContext): Promise<Response> {
 
 	let stored: HeroCurationStored | null = null;
 	try {
-		stored = await c.env.Curated.get(HERO_KV_KEY, "json");
+		stored = await readStored(c.env.Curated);
 	} catch {
 		logCollector.addMessage("Unable to retrieve hero curation from KV");
 		console.error(logCollector.toEndpointLog());
@@ -49,13 +67,14 @@ export async function getHeroCuration(c: ActionContext): Promise<Response> {
 	if (!stored) {
 		logCollector.addMessage("Hero curation empty (no KV value).");
 		console.log(logCollector.toEndpointLog());
-		return c.json({ episodeIds: [], updatedAt: null }, 200);
+		return c.json({ episodeIds: [], railSubjects: [], updatedAt: null }, 200);
 	}
 
 	logCollector.addMessage("Successfully obtained hero curation.");
 	console.log(logCollector.toEndpointLog());
 	return c.json({
-		episodeIds: Array.isArray(stored.episodeIds) ? stored.episodeIds : [],
+		episodeIds: stored.episodeIds,
+		railSubjects: stored.railSubjects,
 		updatedAt: stored.updatedAt ?? null
 	}, 200);
 }
@@ -92,10 +111,30 @@ export async function putHeroCuration(c: Auth0ActionContext): Promise<Response> 
 		console.error(logCollector.toEndpointLog());
 		return c.json({ error: "Bad request" }, 400);
 	}
+	if (!parsed.data.episodeIds && !parsed.data.railSubjects) {
+		logCollector.addMessage("Hero curation body had neither episodeIds nor railSubjects.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Bad request" }, 400);
+	}
 
-	const episodeIds = dedupeAndCap(parsed.data.episodeIds);
+	// Merge so a hero-only or rails-only update leaves the other list intact.
+	let existing: HeroCurationStored | null = null;
+	try {
+		existing = await readStored(c.env.Curated);
+	} catch {
+		logCollector.addMessage("Unable to retrieve hero curation from KV");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Failed to load hero curation" }, 500);
+	}
+
+	const episodeIds = parsed.data.episodeIds
+		? dedupeAndCap(parsed.data.episodeIds, MAX_EPISODE_IDS)
+		: existing?.episodeIds ?? [];
+	const railSubjects = parsed.data.railSubjects
+		? dedupeAndCap(parsed.data.railSubjects.map((subject) => subject.trim()).filter((subject) => subject.length > 0), MAX_RAIL_SUBJECTS)
+		: existing?.railSubjects ?? [];
 	const updatedAt = new Date().toISOString();
-	const stored: HeroCurationStored = { episodeIds, updatedAt };
+	const stored: HeroCurationStored = { episodeIds, railSubjects, updatedAt };
 
 	try {
 		await c.env.Curated.put(HERO_KV_KEY, JSON.stringify(stored));
@@ -105,7 +144,7 @@ export async function putHeroCuration(c: Auth0ActionContext): Promise<Response> 
 		return c.json({ error: "Failed to save hero curation" }, 500);
 	}
 
-	logCollector.addMessage(`Hero curation updated (${episodeIds.length} episodeIds).`);
+	logCollector.addMessage(`Hero curation updated (${episodeIds.length} episodeIds, ${railSubjects.length} railSubjects).`);
 	console.log(logCollector.toEndpointLog());
 	return c.json(stored, 200);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,9 @@ import {
 	PublishPodcastEpisodeRoute,
 	PublishTermRoute,
 	GetDiscoveryScheduleRoute,
+	GetHeroCurationRoute,
 	PutDiscoveryScheduleRoute,
+	PutHeroCurationRoute,
 	PushSubscriptionRoute,
 	RenamePodcastRoute,
 	RunSearchIndexerRoute,
@@ -311,6 +313,8 @@ openapi.post('/publish/homepage', PublishHomepageRoute);
 openapi.post('/terms', PublishTermRoute);
 openapi.get('/discovery-schedule', GetDiscoveryScheduleRoute);
 openapi.put('/discovery-schedule', PutDiscoveryScheduleRoute);
+openapi.get('/hero-curation', GetHeroCurationRoute);
+openapi.put('/hero-curation', PutHeroCurationRoute);
 openapi.post('/podcast/name/:name', RenamePodcastRoute);
 openapi.post('/pushsubscription', PushSubscriptionRoute);
 openapi.get('/pagedetails/:podcastName/:episodeId', GetPageDetailsRoute);

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -30,6 +30,8 @@ import {
 	discoveryScheduleResponseSchema,
 	discoveryScheduleUpdateRequestSchema,
 	discoverySubmitRequestSchema,
+	heroCurationResponseSchema,
+	heroCurationUpdateRequestSchema,
 	discoverySubmitResponseSchema,
 	episodeChangeRequestSchema,
 	episodeDeleteBlockedSchema,
@@ -72,6 +74,7 @@ import { publishPodcastEpisode } from "./publish";
 import { publishHomepage } from "./publishHomepage";
 import { publishTerm } from "./publishTerm";
 import { getDiscoverySchedule, putDiscoverySchedule } from "./discoverySchedule";
+import { getHeroCuration, putHeroCuration } from "./heroCuration";
 import { pushSubscription } from "./pushSubscription";
 import { renamePodcast } from "./renamePodcast";
 import { runSearchIndexer } from "./runSearchIndexer";
@@ -629,6 +632,32 @@ export const PutDiscoveryScheduleRoute = createOpenApiRoute(putDiscoverySchedule
         request: { body: jsonBody(discoveryScheduleUpdateRequestSchema) },
         responses: {
             200: { description: "Schedule updated", ...contentJson(discoveryScheduleResponseSchema) },
+            400: { description: "Bad request", ...contentJson(errorSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
+    }
+});
+
+export const GetHeroCurationRoute = createOpenApiRoute(getHeroCuration, {
+    schema: {
+        tags: ["Public"],
+        summary: "Get curated hero episode IDs",
+        responses: {
+            200: { description: "Hero episode IDs", ...contentJson(heroCurationResponseSchema) },
+            ...serverErrorResponse
+        }
+    }
+});
+
+export const PutHeroCurationRoute = createOpenApiRoute(putHeroCuration, {
+    auth: true,
+    schema: {
+        tags: ["Curation"],
+        summary: "Update curated hero episode IDs",
+        request: { body: jsonBody(heroCurationUpdateRequestSchema) },
+        responses: {
+            200: { description: "Hero curation updated", ...contentJson(heroCurationResponseSchema) },
             400: { description: "Bad request", ...contentJson(errorSchema) },
             ...serverErrorResponse,
             ...authResponses

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -642,9 +642,9 @@ export const PutDiscoveryScheduleRoute = createOpenApiRoute(putDiscoverySchedule
 export const GetHeroCurationRoute = createOpenApiRoute(getHeroCuration, {
     schema: {
         tags: ["Public"],
-        summary: "Get curated hero episode IDs",
+        summary: "Get curated hero episode IDs and pinned rail subjects",
         responses: {
-            200: { description: "Hero episode IDs", ...contentJson(heroCurationResponseSchema) },
+            200: { description: "Hero episode IDs and rail subjects", ...contentJson(heroCurationResponseSchema) },
             ...serverErrorResponse
         }
     }
@@ -654,7 +654,7 @@ export const PutHeroCurationRoute = createOpenApiRoute(putHeroCuration, {
     auth: true,
     schema: {
         tags: ["Curation"],
-        summary: "Update curated hero episode IDs",
+        summary: "Update curated hero episode IDs and/or pinned rail subjects",
         request: { body: jsonBody(heroCurationUpdateRequestSchema) },
         responses: {
             200: { description: "Hero curation updated", ...contentJson(heroCurationResponseSchema) },

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -63,14 +63,20 @@ export const discoveryScheduleResponseSchema = z.object({
 	}))
 });
 
-/** PUT /hero-curation — ordered episode UUID list (handler dedupes and caps at 50). */
+/**
+ * PUT /hero-curation — ordered hero episode UUIDs and/or ordered homepage rail
+ * subjects. Both members are optional so a caller can update one without
+ * clobbering the other; the handler merges, dedupes, and caps each list.
+ */
 export const heroCurationUpdateRequestSchema = z.object({
-	episodeIds: z.array(z.string().uuid())
+	episodeIds: z.array(z.string().uuid()).optional(),
+	railSubjects: z.array(z.string().min(1).max(200)).optional()
 });
 
-/** GET/PUT /hero-curation — curated hero episode IDs. */
+/** GET/PUT /hero-curation — curated hero episode IDs and pinned rail subjects. */
 export const heroCurationResponseSchema = z.object({
 	episodeIds: z.array(z.string().uuid()),
+	railSubjects: z.array(z.string()),
 	updatedAt: z.string().nullable()
 });
 

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -63,6 +63,17 @@ export const discoveryScheduleResponseSchema = z.object({
 	}))
 });
 
+/** PUT /hero-curation — ordered episode UUID list (handler dedupes and caps at 50). */
+export const heroCurationUpdateRequestSchema = z.object({
+	episodeIds: z.array(z.string().uuid())
+});
+
+/** GET/PUT /hero-curation — curated hero episode IDs. */
+export const heroCurationResponseSchema = z.object({
+	episodeIds: z.array(z.string().uuid()),
+	updatedAt: z.string().nullable()
+});
+
 /** GET /discovery-curation — mirrors Api.Dtos.DiscoveryResponse. */
 const discoveryResultUrlsSchema = z.object({
 	spotify: z.string().url().optional().nullable(),

--- a/tests/cors.spec.ts
+++ b/tests/cors.spec.ts
@@ -19,6 +19,15 @@ describe("CORS allowlist (getOrigin)", () => {
 		);
 	});
 
+	it("allows comma-separated staging host suffixes", () => {
+		expect(
+			getOrigin(
+				"https://feat-hero.flix-ac4.pages.dev",
+				"website-83e.pages.dev,flix-ac4.pages.dev"
+			)
+		).toBe("https://feat-hero.flix-ac4.pages.dev");
+	});
+
 	it("allows flix prototype origin", () => {
 		expect(getOrigin("https://flix.cultpodcasts.com", ".pages.dev")).toBe(
 			"https://flix.cultpodcasts.com"

--- a/tests/hero-curation.spec.ts
+++ b/tests/hero-curation.spec.ts
@@ -40,11 +40,22 @@ describe("hero-curation contract", () => {
 		expect(src).toContain("Curated");
 		expect(src).toContain("cacheControlMaxAge: 60");
 		expect(src).toContain('episodeIds: []');
+		expect(src).toContain("railSubjects: []");
 		expect(src).toContain("updatedAt: null");
 	});
 
-	it("dedupes and caps episode IDs at 50", () => {
+	it("dedupes and caps episode IDs at 50 and rail subjects at 12", () => {
 		expect(src).toContain("MAX_EPISODE_IDS = 50");
+		expect(src).toContain("MAX_RAIL_SUBJECTS = 12");
 		expect(src).toContain("dedupeAndCap");
+	});
+
+	it("merges partial updates so hero-only or rails-only PUTs keep the other list", () => {
+		expect(src).toContain("existing?.episodeIds ?? []");
+		expect(src).toContain("existing?.railSubjects ?? []");
+	});
+
+	it("rejects a PUT carrying neither episodeIds nor railSubjects", () => {
+		expect(src).toContain("!parsed.data.episodeIds && !parsed.data.railSubjects");
 	});
 });

--- a/tests/hero-curation.spec.ts
+++ b/tests/hero-curation.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Source-contract checks for /hero-curation (GET public, PUT curate + KV).
+ */
+describe("hero-curation contract", () => {
+	const src = readFileSync(resolve(process.cwd(), "src/heroCuration.ts"), "utf8");
+	const routes = readFileSync(resolve(process.cwd(), "src/openapiRoutes.ts"), "utf8");
+	const index = readFileSync(resolve(process.cwd(), "src/index.ts"), "utf8");
+
+	it("registers GET and PUT /hero-curation", () => {
+		expect(index).toContain("openapi.get('/hero-curation', GetHeroCurationRoute)");
+		expect(index).toContain("openapi.put('/hero-curation', PutHeroCurationRoute)");
+	});
+
+	it("GET is public; PUT requires Auth0 middleware", () => {
+		const getBlock = routes.match(
+			/export const GetHeroCurationRoute = createOpenApiRoute\(getHeroCuration, \{[\s\S]*?\n\}\);/
+		)?.[0];
+		const putBlock = routes.match(
+			/export const PutHeroCurationRoute = createOpenApiRoute\(putHeroCuration, \{[\s\S]*?\n\}\);/
+		)?.[0];
+		expect(getBlock).toBeDefined();
+		expect(putBlock).toBeDefined();
+		expect(getBlock).not.toContain("auth: true");
+		expect(putBlock).toContain("auth: true");
+	});
+
+	it("PUT enforces curate permission with 401/403", () => {
+		expect(src).toContain("permissions?.includes(\"curate\")");
+		expect(src).toContain("401");
+		expect(src).toContain("403");
+		expect(src).toContain("400");
+	});
+
+	it("uses Curated KV key hero-episode-ids and GET cache max-age 60", () => {
+		expect(src).toContain("hero-episode-ids");
+		expect(src).toContain("Curated");
+		expect(src).toContain("cacheControlMaxAge: 60");
+		expect(src).toContain('episodeIds: []');
+		expect(src).toContain("updatedAt: null");
+	});
+
+	it("dedupes and caps episode IDs at 50", () => {
+		expect(src).toContain("MAX_EPISODE_IDS = 50");
+		expect(src).toContain("dedupeAndCap");
+	});
+});

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -13,6 +13,8 @@ import {
 	episodeUpdateResponseSchema,
 	errorSchema,
 	flairsResponseSchema,
+	heroCurationResponseSchema,
+	heroCurationUpdateRequestSchema,
 	homepageResponseSchema,
 	languagesResponseSchema,
 	pageDetailsResponseSchema,
@@ -85,6 +87,26 @@ describe("openapi Zod schemas", () => {
 			}]
 		});
 		expect(parsed.nextRuns).toHaveLength(1);
+	});
+
+	it("accepts hero curation update request and response", () => {
+		const request = heroCurationUpdateRequestSchema.parse({
+			episodeIds: [
+				"550e8400-e29b-41d4-a716-446655440000",
+				"6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+			]
+		});
+		expect(request.episodeIds).toHaveLength(2);
+		expect(heroCurationUpdateRequestSchema.parse({ episodeIds: [] }).episodeIds).toEqual([]);
+		expect(() => heroCurationUpdateRequestSchema.parse({ episodeIds: ["not-a-uuid"] })).toThrow();
+		expect(heroCurationResponseSchema.parse({
+			episodeIds: ["550e8400-e29b-41d4-a716-446655440000"],
+			updatedAt: "2026-07-25T12:00:00.000Z"
+		}).updatedAt).toContain("2026");
+		expect(heroCurationResponseSchema.parse({
+			episodeIds: [],
+			updatedAt: null
+		}).updatedAt).toBeNull();
 	});
 
 	it("accepts flairs map keyed by flair template uuid", () => {

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -101,12 +101,26 @@ describe("openapi Zod schemas", () => {
 		expect(() => heroCurationUpdateRequestSchema.parse({ episodeIds: ["not-a-uuid"] })).toThrow();
 		expect(heroCurationResponseSchema.parse({
 			episodeIds: ["550e8400-e29b-41d4-a716-446655440000"],
+			railSubjects: ["Scientology"],
 			updatedAt: "2026-07-25T12:00:00.000Z"
 		}).updatedAt).toContain("2026");
 		expect(heroCurationResponseSchema.parse({
 			episodeIds: [],
+			railSubjects: [],
 			updatedAt: null
 		}).updatedAt).toBeNull();
+	});
+
+	it("accepts rails-only and hero-only hero curation updates", () => {
+		const railsOnly = heroCurationUpdateRequestSchema.parse({
+			railSubjects: ["Scientology", "FLDS Church"]
+		});
+		expect(railsOnly.railSubjects).toHaveLength(2);
+		expect(railsOnly.episodeIds).toBeUndefined();
+		expect(heroCurationUpdateRequestSchema.parse({
+			episodeIds: ["550e8400-e29b-41d4-a716-446655440000"]
+		}).railSubjects).toBeUndefined();
+		expect(() => heroCurationUpdateRequestSchema.parse({ railSubjects: [""] })).toThrow();
 	});
 
 	it("accepts flairs map keyed by flair template uuid", () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,6 +27,10 @@
     {
       "binding": "shortner",
       "id": "663cd5c74988404dafbf67e1e06b21e8"
+    },
+    {
+      "binding": "Curated",
+      "id": "564b9b11748e4d3c9da703fe019e3176"
     }
   ],
   "analytics_engine_datasets": [
@@ -93,6 +97,10 @@
         {
           "binding": "shortner",
           "id": "663cd5c74988404dafbf67e1e06b21e8"
+        },
+        {
+          "binding": "Curated",
+          "id": "564b9b11748e4d3c9da703fe019e3176"
         }
       ],
       "analytics_engine_datasets": [
@@ -149,6 +157,10 @@
         {
           "binding": "shortner",
           "id": "663cd5c74988404dafbf67e1e06b21e8"
+        },
+        {
+          "binding": "Curated",
+          "id": "564b9b11748e4d3c9da703fe019e3176"
         }
       ],
       "analytics_engine_datasets": [
@@ -189,6 +201,10 @@
         {
           "binding": "shortner",
           "id": "663cd5c74988404dafbf67e1e06b21e8"
+        },
+        {
+          "binding": "Curated",
+          "id": "564b9b11748e4d3c9da703fe019e3176"
         }
       ],
       "analytics_engine_datasets": [


### PR DESCRIPTION
## Summary
- Add public `GET /hero-curation` and curate-scoped `PUT /hero-curation` on the Cloudflare API worker
- Persist ordered episode UUIDs in a new `Curated` KV namespace (key `hero-episode-ids`)
- OpenAPI/Zod schemas, CORS via existing middleware, tests for schemas + source contract

## API contract
- **GET /hero-curation** — public, no auth. `200`: `{ episodeIds: string[], updatedAt: string | null }`. Empty KV → `{ episodeIds: [], updatedAt: null }`. Cache-Control max-age `60`.
- **PUT /hero-curation** — Bearer JWT with `curate`. Body `{ episodeIds: string[] }` (ordered; deduped; capped at 50; empty clears). `200`: `{ episodeIds, updatedAt }`. `401` / `403` / `400` as specified.
- OPTIONS/CORS consistent with existing routes (`hono/cors` + `AddResponseHeaders`).

## Week / homepage pruning (client responsibility)
Curated heroes **auto-drop when they leave the current week**. The worker keeps GET/PUT as a **dumb ordered ID list** — it does **not** prune against the homepage week window (that would require parsing homepage R2 on every GET).

Clients should:
1. Intersect curated IDs with homepage `recentEpisodes` (current week)
2. Drop IDs no longer present
3. Optionally `PUT` the cleaned list back so KV stays tidy

## KV namespace
- Created: `curated-content` → id `564b9b11748e4d3c9da703fe019e3176`
- Binding `Curated` wired in top-level + `local` / `preview` / `production` env blocks in `wrangler.jsonc`
- **Not deployed** by this PR (no `wrangler deploy`)

## Test plan
- [x] `npm run lint` (tsc --noEmit)
- [x] `npm test` (38 passed)
- [ ] After merge/deploy: smoke GET empty state, PUT with curate token, GET returns stored IDs