### PR TITLE
fix(api): episode lookup when podcast name contains a slash

### DIFF
--- a/src/azureEpisodePathSuffix.ts
+++ b/src/azureEpisodePathSuffix.ts
@@ -1,0 +1,14 @@
+/**
+ * Build the Azure Functions path suffix for an episode lookup by podcast name.
+ *
+ * Azure (and most hosts) decode `%2F` before routing, so a podcast name that
+ * contains `/` (e.g. "The FOX True Crime Podcast w/ Emily Compagno") cannot be
+ * placed in a single path segment — the request 404s. Fall back to the
+ * episode-id-only route in that case.
+ */
+export function azureEpisodePathSuffix(podcastName: string, episodeId: string): string {
+	if (podcastName.includes("/")) {
+		return `/${encodeURIComponent(episodeId)}`;
+	}
+	return `/${encodeURIComponent(podcastName)}/${encodeURIComponent(episodeId)}`;
+}

--- a/src/encodeUrlParameter.ts
+++ b/src/encodeUrlParameter.ts
@@ -1,4 +1,0 @@
-export function encodeUrlParameter(parameter: string): string {
-    parameter = parameter.replace("/", encodeURIComponent("/"));
-    return encodeURIComponent(parameter);
-}

--- a/src/getEpisode.ts
+++ b/src/getEpisode.ts
@@ -1,5 +1,6 @@
 import { AddResponseHeaders } from "./AddResponseHeaders";
 import { Auth0ActionContext } from "./Auth0ActionContext";
+import { azureEpisodePathSuffix } from "./azureEpisodePathSuffix";
 import { Endpoint } from "./Endpoint";
 import { proxyToAzure } from "./proxyToAzure";
 
@@ -31,7 +32,7 @@ export async function getPodcastEpisode(c: Auth0ActionContext): Promise<Response
 		permission: "curate",
 		endpoint: Endpoint.episode,
 		method: "GET",
-		pathSuffix: `/${encodeURIComponent(podcastName)}/${encodeURIComponent(episodeId)}`,
+		pathSuffix: azureEpisodePathSuffix(podcastName, episodeId),
 		successStatuses: [200],
 		forwardStatuses: [404],
 		logName: "secure-episode-endpoint"

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,7 +283,9 @@ openapi.post('/submit', SubmitRoute);
 openapi.post('/episode/publish/:podcastId/:episodeId', PublishPodcastEpisodeRoute);
 // \New Episode Publish Endpoint
 // New Episode Endpoints
-openapi.get('/episode/:podcastName/:episodeId', GetPodcastEpisodeRoute);
+// podcastName may contain `/` (encoded as %2F). Use a greedy matcher so a
+// decoded slash still binds to podcastName rather than splitting the route.
+openapi.get('/episode/:podcastName{.+}/:episodeId{[0-9a-fA-F-]{36}}', GetPodcastEpisodeRoute);
 openapi.post('/episode/:podcastId/:episodeId', UpdatePodcastEpisodeRoute);
 openapi.delete('/episode/:podcastId/:episodeId', DeletePodcastEpisodeRoute);
 // \New Episode Endpoints

--- a/tests/azure-episode-path-suffix.spec.ts
+++ b/tests/azure-episode-path-suffix.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { azureEpisodePathSuffix } from "../src/azureEpisodePathSuffix";
+
+describe("azureEpisodePathSuffix", () => {
+	it("keeps podcast name + episode id when the name has no slash", () => {
+		expect(azureEpisodePathSuffix("Cult Psychology", "efbc1f08-eebd-43ed-b69b-ebffc45e1440"))
+			.toBe("/Cult%20Psychology/efbc1f08-eebd-43ed-b69b-ebffc45e1440");
+	});
+
+	it("falls back to episode-id-only when the podcast name contains a slash", () => {
+		expect(
+			azureEpisodePathSuffix(
+				"The FOX True Crime Podcast w/ Emily Compagno",
+				"efbc1f08-eebd-43ed-b69b-ebffc45e1440"
+			)
+		).toBe("/efbc1f08-eebd-43ed-b69b-ebffc45e1440");
+	});
+});


### PR DESCRIPTION
## Summary
- Podcast names with `/` (e.g. `The FOX True Crime Podcast w/ Emily Compagno`) cannot be sent as a single Azure Functions path segment — the host decodes `%2F` and the route 404s.
- When the name contains `/`, the Worker now proxies to the episode-id-only Azure route.
- Hono route uses a greedy `podcastName` matcher so a decoded slash does not split Worker routing.

## Test plan
- [ ] Authenticated GET `https://api.cultpodcasts.com/episode/The%20FOX%20True%20Crime%20Podcast%20w%2F%20Emily%20Compagno/efbc1f08-eebd-43ed-b69b-ebffc45e1440` returns 200 (not 404)
- [ ] Normal podcast names without `/` still resolve via name + episode id
- [ ] `npm test -- --run tests/azure-episode-path-suffix.spec.ts` green