### PR TITLE
fix(api): SQLite ProfileDurableObject on preview for bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,29 @@ Local development uses HTTPS with a custom trusted certificate and listens on `1
 
 ### Why `env.local` exists
 
-`wrangler.jsonc` keeps production migrations (`v1`, `v2`, `v3`) unchanged for deploys, and also defines `env.local.migrations` with a local baseline migration for `ProfileDurableObject`.
+`wrangler.jsonc` keeps top-level production migrations (`v1`, `v2`, `v3`) unchanged for deploys, and also defines per-environment migrations:
 
-This avoids the local Durable Object replay error:
+| Env | Worker name | Profile DO storage |
+|-----|-------------|--------------------|
+| *(default)* | `api` | Top-level `v1`→`v3` (SQLite via `new_sqlite_classes`) |
+| `local` | local only | `local-v1` with `new_sqlite_classes` |
+| `preview` | `api-preview` | Cut over via `preview-v2` (rename KV aside + SQLite) then `preview-v3` (delete legacy). **Already applied on api-preview.** |
+| `production` | `api-production` | Same cutover prepared (`production-v2`); deploy with the temporary `PROFILE_DURABLE_OBJECT_LEGACY` binding, then remove that binding and add `production-v3` `deleted_classes` in a follow-up deploy. Default prod uses top-level `api`, not this env. |
+
+`env.local` avoids the local Durable Object replay error:
 
 `Cannot apply new_sqlite_classes migration to existing class ProfileDurableObject`
 
-Deploys still use the top-level production migration history:
+`ProfileDurableObject` uses `ctx.storage.sql`, which **requires** a SQLite-backed class (`new_sqlite_classes`). A preview/production named-env class created with only `new_classes` (KV) will throw on bookmark routes (Worker 500).
+
+Default production deploys use the top-level migration history:
 
 ```bash
 npm run deploy
+```
+
+Preview (e.g. `api-preview.jonbreen.workers.dev`):
+
+```bash
+npx wrangler deploy --env preview
 ```

--- a/src/ProfileDurableObjectLegacy.ts
+++ b/src/ProfileDurableObjectLegacy.ts
@@ -1,0 +1,14 @@
+import { DurableObject } from "cloudflare:workers";
+import { Env } from "./Env";
+
+/**
+ * Temporary migration target for renaming the KV-backed ProfileDurableObject
+ * aside (preview-v2 / production-v2) before creating a SQLite-backed class with
+ * the original name. Safe to delete from the codebase after preview-v3 /
+ * production-v3 have been applied to every named env that needed the cutover.
+ */
+export class ProfileDurableObjectLegacy extends DurableObject {
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env);
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { Env } from './Env';
 import { Auth0JwtPayload } from './Auth0JwtPayload';
 import { corsOptions } from "./corsOptions";
 import { ProfileDurableObject } from './ProfileDurableObject';
+import { ProfileDurableObjectLegacy } from './ProfileDurableObjectLegacy';
 import { buildDocsPageHtml } from './resources/docsPageHtml';
 import {
 	AddBookmarkRoute,
@@ -325,4 +326,4 @@ openapi.get('/public/episode/:id', PublicGetEpisodeRoute);
 openapi.get('/languages', GetLanguagesRoute);
 
 export default app;
-export { ProfileDurableObject };
+export { ProfileDurableObject, ProfileDurableObjectLegacy };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -116,24 +116,41 @@
           }
         ]
       },
+      // preview-v1 created a KV-backed DO; ProfileDurableObject uses ctx.storage.sql
+      // (SQLite only). preview-v2 renames the KV class aside and creates a SQLite
+      // class under the original name; preview-v3 deletes the legacy KV class
+      // (requires the temporary PROFILE_DURABLE_OBJECT_LEGACY binding to already
+      // have been removed — applied in the deploy after preview-v2).
       "migrations": [
         {
           "tag": "preview-v1",
           "new_classes": [
             "ProfileDurableObject"
           ]
+        },
+        {
+          "tag": "preview-v2",
+          "renamed_classes": [
+            {
+              "from": "ProfileDurableObject",
+              "to": "ProfileDurableObjectLegacy"
+            }
+          ],
+          "new_sqlite_classes": [
+            "ProfileDurableObject"
+          ]
+        },
+        {
+          "tag": "preview-v3",
+          "deleted_classes": [
+            "ProfileDurableObjectLegacy"
+          ]
         }
       ]
     },
     "production": {
-      "migrations": [
-        {
-          "tag": "production-v1",
-          "new_classes": [
-            "ProfileDurableObject"
-          ]
-        }
-      ],
+      // Same KV→SQLite cutover as preview if this named env was ever deployed.
+      // Default `npm run deploy` uses top-level migrations (v1–v3), not this block.
       "r2_buckets": [
         {
           "binding": "Content",
@@ -173,9 +190,33 @@
           {
             "name": "PROFILE_DURABLE_OBJECT",
             "class_name": "ProfileDurableObject"
+          },
+          {
+            "name": "PROFILE_DURABLE_OBJECT_LEGACY",
+            "class_name": "ProfileDurableObjectLegacy"
           }
         ]
-      }
+      },
+      "migrations": [
+        {
+          "tag": "production-v1",
+          "new_classes": [
+            "ProfileDurableObject"
+          ]
+        },
+        {
+          "tag": "production-v2",
+          "renamed_classes": [
+            {
+              "from": "ProfileDurableObject",
+              "to": "ProfileDurableObjectLegacy"
+            }
+          ],
+          "new_sqlite_classes": [
+            "ProfileDurableObject"
+          ]
+        }
+      ]
     },
     "local": {
       "r2_buckets": [


### PR DESCRIPTION
## Summary
- Root cause: `api-preview` provisioned `ProfileDurableObject` with KV storage (`preview-v1` / `new_classes`), but `ProfileDurableObject` uses `ctx.storage.sql` (SQLite-only) → authenticated bookmark routes threw and returned Worker 500.
- Cut over preview via rename + `new_sqlite_classes` (`preview-v2`) then delete legacy (`preview-v3`). **Already deployed to `api-preview`.**
- Prepare the same cutover for the named `production` env (`api-production`); default `npm run deploy` / top-level `api` is unchanged.
- Website staging already points at `https://api-preview.jonbreen.workers.dev` — no website change required.

## Test plan
- [x] `npm run lint` / `npm test`
- [x] `wrangler deploy --env preview` applied `preview-v2` and `preview-v3`
- [ ] Signed-in on website Pages preview: POST `/bookmark/:id` returns 200 (or 409 if already bookmarked), not 500
- [ ] GET `/bookmarks` returns an array
- [ ] Do **not** merge until bookmark smoke on preview is confirmed