### PR TITLE
feat(api): hero curation Durable Object with always-promote append

### DIFF
--- a/src/Env.ts
+++ b/src/Env.ts
@@ -23,6 +23,7 @@ export type Env = {
 	securePushSubscriptionEndpoint: URL;
 	stagingHostSuffix: string;
 	PROFILE_DURABLE_OBJECT: DurableObjectNamespace<import("./ProfileDurableObject").ProfileDurableObject>;
+	HERO_CURATION_DURABLE_OBJECT: DurableObjectNamespace<import("./HeroCurationDurableObject").HeroCurationDurableObject>;
 	Content: R2Bucket;
 	Data: R2Bucket;
 	apiDB: D1Database;

--- a/src/HeroCurationDurableObject.ts
+++ b/src/HeroCurationDurableObject.ts
@@ -1,0 +1,135 @@
+import { DurableObject } from "cloudflare:workers";
+import { Env } from "./Env";
+import {
+	dedupeAndCap,
+	emptyHeroState,
+	HERO_KV_KEY,
+	HeroCurationReplaceInput,
+	HeroCurationReplaceResult,
+	HeroCurationState,
+	MAX_EPISODE_IDS,
+	MAX_RAIL_SUBJECTS,
+	mergeAppendEpisodes,
+	mergePruneToAllowed,
+	storedList
+} from "./heroCurationLogic";
+
+export {
+	dedupeAndCap,
+	HERO_KV_KEY,
+	MAX_EPISODE_IDS,
+	MAX_RAIL_SUBJECTS,
+	type HeroCurationState
+} from "./heroCurationLogic";
+
+const STORAGE_KEY = "state";
+
+/**
+ * Single global Durable Object owning the ordered hero list and rail subjects.
+ * All mutations are serialized here so curator / indexer / cron cannot clobber order.
+ */
+export class HeroCurationDurableObject extends DurableObject<Env> {
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env);
+	}
+
+	async get(): Promise<HeroCurationState> {
+		return this.loadOrMigrate();
+	}
+
+	async replace(input: HeroCurationReplaceInput): Promise<HeroCurationReplaceResult> {
+		const current = await this.loadOrMigrate();
+		if (
+			input.expectedUpdatedAt != null &&
+			input.expectedUpdatedAt !== "" &&
+			input.expectedUpdatedAt !== current.updatedAt
+		) {
+			return { ok: false, conflict: true, state: current };
+		}
+
+		const episodeIds = input.episodeIds
+			? dedupeAndCap(input.episodeIds, MAX_EPISODE_IDS)
+			: current.episodeIds;
+		const railSubjects = input.railSubjects
+			? dedupeAndCap(
+				input.railSubjects.map((subject) => subject.trim()).filter((subject) => subject.length > 0),
+				MAX_RAIL_SUBJECTS
+			)
+			: current.railSubjects;
+
+		const state: HeroCurationState = {
+			episodeIds,
+			railSubjects,
+			updatedAt: new Date().toISOString()
+		};
+		await this.ctx.storage.put(STORAGE_KEY, state);
+		return { ok: true, state };
+	}
+
+	async appendEpisodes(episodeIds: string[]): Promise<HeroCurationState> {
+		const current = await this.loadOrMigrate();
+		const next = mergeAppendEpisodes(current, episodeIds);
+		if (!next) {
+			console.log(
+				`Hero auto-promote: DO append no-op (already present or empty). EpisodeIds: ${episodeIds.join(",")}. Total: ${current.episodeIds.length}.`
+			);
+			return current;
+		}
+		await this.ctx.storage.put(STORAGE_KEY, next);
+		console.log(
+			`Hero auto-promote: DO stored append. EpisodeIds: ${episodeIds.join(",")}. Total: ${next.episodeIds.length}. UpdatedAt: ${next.updatedAt}.`
+		);
+		return next;
+	}
+
+	async pruneToAllowedIds(
+		allowedEpisodeIds: string[],
+		allowedRailSubjects?: string[]
+	): Promise<{ state: HeroCurationState; pruned: boolean }> {
+		const current = await this.loadOrMigrate();
+		const result = mergePruneToAllowed(current, allowedEpisodeIds, allowedRailSubjects);
+		if (!result.pruned) {
+			return result;
+		}
+		await this.ctx.storage.put(STORAGE_KEY, result.state);
+		return result;
+	}
+
+	private async loadOrMigrate(): Promise<HeroCurationState> {
+		const stored = await this.ctx.storage.get<HeroCurationState>(STORAGE_KEY);
+		if (stored && Array.isArray(stored.episodeIds) && Array.isArray(stored.railSubjects)) {
+			return {
+				episodeIds: storedList(stored.episodeIds),
+				railSubjects: storedList(stored.railSubjects),
+				updatedAt: stored.updatedAt ?? new Date(0).toISOString()
+			};
+		}
+
+		try {
+			const fromKv = await this.env.Curated.get<Partial<HeroCurationState>>(HERO_KV_KEY, "json");
+			if (fromKv) {
+				const migrated: HeroCurationState = {
+					episodeIds: dedupeAndCap(storedList(fromKv.episodeIds), MAX_EPISODE_IDS),
+					railSubjects: dedupeAndCap(storedList(fromKv.railSubjects), MAX_RAIL_SUBJECTS),
+					updatedAt: fromKv.updatedAt ?? new Date().toISOString()
+				};
+				await this.ctx.storage.put(STORAGE_KEY, migrated);
+				return migrated;
+			}
+		} catch (error) {
+			console.error("HeroCurationDurableObject: KV migrate failed", error);
+		}
+
+		const empty = emptyHeroState();
+		await this.ctx.storage.put(STORAGE_KEY, empty);
+		return empty;
+	}
+}
+
+export function heroCurationStub(
+	env: Env
+): DurableObjectStub<HeroCurationDurableObject> {
+	const id = env.HERO_CURATION_DURABLE_OBJECT.idFromName("global");
+	return env.HERO_CURATION_DURABLE_OBJECT.get(id);
+}
+

--- a/src/heroCuration.ts
+++ b/src/heroCuration.ts
@@ -3,97 +3,59 @@ import { ActionContext } from "./ActionContext";
 import { Auth0ActionContext } from "./Auth0ActionContext";
 import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { LogCollector } from "./LogCollector";
-import { heroCurationUpdateRequestSchema } from "./openapiSchemas";
+import {
+	heroCurationAppendRequestSchema,
+	heroCurationUpdateRequestSchema
+} from "./openapiSchemas";
+import { heroCurationStub } from "./HeroCurationDurableObject";
 
-const HERO_KV_KEY = "hero-episode-ids";
-const MAX_EPISODE_IDS = 50;
-const MAX_RAIL_SUBJECTS = 12;
-
-type HeroCurationStored = {
-	episodeIds: string[];
-	railSubjects: string[];
-	updatedAt: string;
-};
-
-function dedupeAndCap(values: string[], max: number): string[] {
-	const seen = new Set<string>();
-	const result: string[] = [];
-	for (const value of values) {
-		if (seen.has(value)) {
-			continue;
-		}
-		seen.add(value);
-		result.push(value);
-		if (result.length >= max) {
-			break;
-		}
+function requireCurate(c: Auth0ActionContext, logCollector: LogCollector): Response | null {
+	const auth0Payload: Auth0JwtPayload = c.var.auth0("payload");
+	if (!auth0Payload) {
+		logCollector.addMessage("Unauthorised to mutate hero curation.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Unauthorised" }, 401);
 	}
-	return result;
-}
-
-function storedList(value: unknown): string[] {
-	return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
-}
-
-async function readStored(kv: KVNamespace): Promise<HeroCurationStored | null> {
-	const stored = await kv.get<Partial<HeroCurationStored>>(HERO_KV_KEY, "json");
-	if (!stored) {
-		return null;
+	if (!auth0Payload.permissions?.includes("curate")) {
+		logCollector.addMessage("Forbidden to mutate hero curation.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Forbidden" }, 403);
 	}
-	return {
-		episodeIds: storedList(stored.episodeIds),
-		railSubjects: storedList(stored.railSubjects),
-		updatedAt: stored.updatedAt ?? new Date(0).toISOString()
-	};
+	return null;
 }
 
 export async function getHeroCuration(c: ActionContext): Promise<Response> {
 	const logCollector = new LogCollector();
 	logCollector.collectRequest(c);
 	AddResponseHeaders(c, {
-		methods: ["GET", "PUT", "OPTIONS"],
+		methods: ["GET", "PUT", "POST", "OPTIONS"],
 		cacheControlMaxAge: 60
 	});
 
-	let stored: HeroCurationStored | null = null;
 	try {
-		stored = await readStored(c.env.Curated);
-	} catch {
-		logCollector.addMessage("Unable to retrieve hero curation from KV");
-		console.error(logCollector.toEndpointLog());
+		const state = await heroCurationStub(c.env).get();
+		logCollector.addMessage("Successfully obtained hero curation.");
+		console.log(logCollector.toEndpointLog());
+		return c.json({
+			episodeIds: state.episodeIds,
+			railSubjects: state.railSubjects,
+			updatedAt: state.updatedAt ?? null
+		}, 200);
+	} catch (error) {
+		logCollector.addMessage("Unable to retrieve hero curation from Durable Object");
+		console.error(logCollector.toEndpointLog(), error);
 		return c.json({ error: "Failed to load hero curation" }, 500);
 	}
-
-	if (!stored) {
-		logCollector.addMessage("Hero curation empty (no KV value).");
-		console.log(logCollector.toEndpointLog());
-		return c.json({ episodeIds: [], railSubjects: [], updatedAt: null }, 200);
-	}
-
-	logCollector.addMessage("Successfully obtained hero curation.");
-	console.log(logCollector.toEndpointLog());
-	return c.json({
-		episodeIds: stored.episodeIds,
-		railSubjects: stored.railSubjects,
-		updatedAt: stored.updatedAt ?? null
-	}, 200);
 }
 
 export async function putHeroCuration(c: Auth0ActionContext): Promise<Response> {
-	const auth0Payload: Auth0JwtPayload = c.var.auth0("payload");
 	const logCollector = new LogCollector();
 	logCollector.collectRequest(c);
-	AddResponseHeaders(c, { methods: ["GET", "PUT", "OPTIONS"] });
+	AddResponseHeaders(c, { methods: ["GET", "PUT", "POST", "OPTIONS"] });
 
-	if (!auth0Payload) {
-		logCollector.addMessage("Unauthorised to use putHeroCuration.");
-		console.error(logCollector.toEndpointLog());
-		return c.json({ error: "Unauthorised" }, 401);
-	}
-	if (!auth0Payload.permissions?.includes("curate")) {
-		logCollector.addMessage("Forbidden to use putHeroCuration.");
-		console.error(logCollector.toEndpointLog());
-		return c.json({ error: "Forbidden" }, 403);
+	const denied = requireCurate(c, logCollector);
+	if (denied) {
+		return denied;
 	}
 
 	let body: unknown;
@@ -117,34 +79,73 @@ export async function putHeroCuration(c: Auth0ActionContext): Promise<Response> 
 		return c.json({ error: "Bad request" }, 400);
 	}
 
-	// Merge so a hero-only or rails-only update leaves the other list intact.
-	let existing: HeroCurationStored | null = null;
 	try {
-		existing = await readStored(c.env.Curated);
-	} catch {
-		logCollector.addMessage("Unable to retrieve hero curation from KV");
-		console.error(logCollector.toEndpointLog());
-		return c.json({ error: "Failed to load hero curation" }, 500);
-	}
+		const result = await heroCurationStub(c.env).replace({
+			episodeIds: parsed.data.episodeIds,
+			railSubjects: parsed.data.railSubjects,
+			expectedUpdatedAt: parsed.data.expectedUpdatedAt
+		});
+		if (!result.ok) {
+			logCollector.addMessage("Hero curation conflict (expectedUpdatedAt mismatch).");
+			console.warn(logCollector.toEndpointLog());
+			return c.json({
+				error: "Conflict",
+				episodeIds: result.state.episodeIds,
+				railSubjects: result.state.railSubjects,
+				updatedAt: result.state.updatedAt
+			}, 409);
+		}
 
-	const episodeIds = parsed.data.episodeIds
-		? dedupeAndCap(parsed.data.episodeIds, MAX_EPISODE_IDS)
-		: existing?.episodeIds ?? [];
-	const railSubjects = parsed.data.railSubjects
-		? dedupeAndCap(parsed.data.railSubjects.map((subject) => subject.trim()).filter((subject) => subject.length > 0), MAX_RAIL_SUBJECTS)
-		: existing?.railSubjects ?? [];
-	const updatedAt = new Date().toISOString();
-	const stored: HeroCurationStored = { episodeIds, railSubjects, updatedAt };
-
-	try {
-		await c.env.Curated.put(HERO_KV_KEY, JSON.stringify(stored));
-	} catch {
-		logCollector.addMessage("Unable to store hero curation in KV");
-		console.error(logCollector.toEndpointLog());
+		logCollector.addMessage(
+			`Hero curation updated (${result.state.episodeIds.length} episodeIds, ${result.state.railSubjects.length} railSubjects).`
+		);
+		console.log(logCollector.toEndpointLog());
+		return c.json(result.state, 200);
+	} catch (error) {
+		logCollector.addMessage("Unable to store hero curation in Durable Object");
+		console.error(logCollector.toEndpointLog(), error);
 		return c.json({ error: "Failed to save hero curation" }, 500);
 	}
-
-	logCollector.addMessage(`Hero curation updated (${episodeIds.length} episodeIds, ${railSubjects.length} railSubjects).`);
-	console.log(logCollector.toEndpointLog());
-	return c.json(stored, 200);
 }
+
+export async function appendHeroCurationEpisodes(c: Auth0ActionContext): Promise<Response> {
+	const logCollector = new LogCollector();
+	logCollector.collectRequest(c);
+	AddResponseHeaders(c, { methods: ["GET", "PUT", "POST", "OPTIONS"] });
+
+	const denied = requireCurate(c, logCollector);
+	if (denied) {
+		return denied;
+	}
+
+	let body: unknown;
+	try {
+		body = await c.req.json();
+	} catch {
+		logCollector.addMessage("Invalid JSON body for appendHeroCurationEpisodes.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Bad request" }, 400);
+	}
+
+	const parsed = heroCurationAppendRequestSchema.safeParse(body);
+	if (!parsed.success || parsed.data.episodeIds.length === 0) {
+		logCollector.addMessage("Invalid hero curation append body.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Bad request" }, 400);
+	}
+
+	try {
+		const requested = parsed.data.episodeIds;
+		const state = await heroCurationStub(c.env).appendEpisodes(requested);
+		logCollector.addMessage(
+			`Hero auto-promote: DO append (${requested.length} requested, ${state.episodeIds.length} total). EpisodeIds: ${requested.join(",")}.`
+		);
+		console.log(logCollector.toEndpointLog());
+		return c.json(state, 200);
+	} catch (error) {
+		logCollector.addMessage("Hero auto-promote: unable to append hero curation episodes");
+		console.error(logCollector.toEndpointLog(), error);
+		return c.json({ error: "Failed to append hero episodes" }, 500);
+	}
+}
+

--- a/src/heroCurationLogic.ts
+++ b/src/heroCurationLogic.ts
@@ -1,0 +1,102 @@
+export const HERO_KV_KEY = "hero-episode-ids";
+export const MAX_EPISODE_IDS = 50;
+export const MAX_RAIL_SUBJECTS = 12;
+
+export type HeroCurationState = {
+	episodeIds: string[];
+	railSubjects: string[];
+	updatedAt: string;
+};
+
+export type HeroCurationReplaceInput = {
+	episodeIds?: string[];
+	railSubjects?: string[];
+	expectedUpdatedAt?: string | null;
+};
+
+export type HeroCurationReplaceResult =
+	| { ok: true; state: HeroCurationState }
+	| { ok: false; conflict: true; state: HeroCurationState };
+
+export function storedList(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+export function dedupeAndCap(values: string[], max: number): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const value of values) {
+		if (seen.has(value)) {
+			continue;
+		}
+		seen.add(value);
+		result.push(value);
+		if (result.length >= max) {
+			break;
+		}
+	}
+	return result;
+}
+
+export function emptyHeroState(): HeroCurationState {
+	return {
+		episodeIds: [],
+		railSubjects: [],
+		updatedAt: new Date(0).toISOString()
+	};
+}
+
+export function mergeAppendEpisodes(
+	current: HeroCurationState,
+	episodeIds: string[]
+): HeroCurationState | null {
+	const incoming = dedupeAndCap(episodeIds, MAX_EPISODE_IDS);
+	if (incoming.length === 0) {
+		return null;
+	}
+	const existing = new Set(current.episodeIds);
+	const toPrepend = incoming.filter((id) => !existing.has(id));
+	if (toPrepend.length === 0) {
+		return null;
+	}
+	return {
+		episodeIds: dedupeAndCap([...toPrepend, ...current.episodeIds], MAX_EPISODE_IDS),
+		railSubjects: current.railSubjects,
+		updatedAt: new Date().toISOString()
+	};
+}
+
+export function mergePruneToAllowed(
+	current: HeroCurationState,
+	allowedEpisodeIds: string[],
+	allowedRailSubjects?: string[]
+): { state: HeroCurationState; pruned: boolean } {
+	const episodeAllow = new Set(allowedEpisodeIds);
+	const nextEpisodes = current.episodeIds.filter((id) => episodeAllow.has(id));
+
+	let nextRails = current.railSubjects;
+	if (allowedRailSubjects) {
+		const railAllow = new Set(allowedRailSubjects);
+		nextRails = current.railSubjects.filter((subject) => railAllow.has(subject));
+	}
+
+	const pruned =
+		nextEpisodes.length !== current.episodeIds.length ||
+		nextEpisodes.some((id, i) => id !== current.episodeIds[i]) ||
+		nextRails.length !== current.railSubjects.length ||
+		nextRails.some((subject, i) => subject !== current.railSubjects[i]);
+
+	if (!pruned) {
+		return { state: current, pruned: false };
+	}
+
+	return {
+		state: {
+			episodeIds: nextEpisodes,
+			railSubjects: nextRails,
+			updatedAt: new Date().toISOString()
+		},
+		pruned: true
+	};
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { Auth0JwtPayload } from './Auth0JwtPayload';
 import { corsOptions } from "./corsOptions";
 import { ProfileDurableObject } from './ProfileDurableObject';
 import { ProfileDurableObjectLegacy } from './ProfileDurableObjectLegacy';
+import { HeroCurationDurableObject } from './HeroCurationDurableObject';
+import { pruneHeroCurationScheduled } from './pruneHeroCurationScheduled';
 import { buildDocsPageHtml } from './resources/docsPageHtml';
 import {
 	AddBookmarkRoute,
@@ -39,6 +41,7 @@ import {
 	PublishPodcastEpisodeRoute,
 	PublishTermRoute,
 	GetDiscoveryScheduleRoute,
+	AppendHeroCurationEpisodesRoute,
 	GetHeroCurationRoute,
 	PutDiscoveryScheduleRoute,
 	PutHeroCurationRoute,
@@ -316,6 +319,7 @@ openapi.get('/discovery-schedule', GetDiscoveryScheduleRoute);
 openapi.put('/discovery-schedule', PutDiscoveryScheduleRoute);
 openapi.get('/hero-curation', GetHeroCurationRoute);
 openapi.put('/hero-curation', PutHeroCurationRoute);
+openapi.post('/hero-curation/episodes', AppendHeroCurationEpisodesRoute);
 openapi.post('/podcast/name/:name', RenamePodcastRoute);
 openapi.post('/pushsubscription', PushSubscriptionRoute);
 openapi.get('/pagedetails/:podcastName/:episodeId', GetPageDetailsRoute);
@@ -325,5 +329,10 @@ openapi.get('/bookmarks', GetBookmarksRoute);
 openapi.get('/public/episode/:id', PublicGetEpisodeRoute);
 openapi.get('/languages', GetLanguagesRoute);
 
-export default app;
-export { ProfileDurableObject, ProfileDurableObjectLegacy };
+export default {
+	fetch: app.fetch,
+	async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext) {
+		ctx.waitUntil(pruneHeroCurationScheduled(env));
+	}
+};
+export { ProfileDurableObject, ProfileDurableObjectLegacy, HeroCurationDurableObject };

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -32,6 +32,7 @@ import {
 	discoverySubmitRequestSchema,
 	heroCurationResponseSchema,
 	heroCurationUpdateRequestSchema,
+	heroCurationAppendRequestSchema,
 	discoverySubmitResponseSchema,
 	episodeChangeRequestSchema,
 	episodeDeleteBlockedSchema,
@@ -74,7 +75,7 @@ import { publishPodcastEpisode } from "./publish";
 import { publishHomepage } from "./publishHomepage";
 import { publishTerm } from "./publishTerm";
 import { getDiscoverySchedule, putDiscoverySchedule } from "./discoverySchedule";
-import { getHeroCuration, putHeroCuration } from "./heroCuration";
+import { appendHeroCurationEpisodes, getHeroCuration, putHeroCuration } from "./heroCuration";
 import { pushSubscription } from "./pushSubscription";
 import { renamePodcast } from "./renamePodcast";
 import { runSearchIndexer } from "./runSearchIndexer";
@@ -658,6 +659,22 @@ export const PutHeroCurationRoute = createOpenApiRoute(putHeroCuration, {
         request: { body: jsonBody(heroCurationUpdateRequestSchema) },
         responses: {
             200: { description: "Hero curation updated", ...contentJson(heroCurationResponseSchema) },
+            400: { description: "Bad request", ...contentJson(errorSchema) },
+            409: { description: "Conflict — expectedUpdatedAt mismatch", ...contentJson(heroCurationResponseSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
+    }
+});
+
+export const AppendHeroCurationEpisodesRoute = createOpenApiRoute(appendHeroCurationEpisodes, {
+    auth: true,
+    schema: {
+        tags: ["Curation"],
+        summary: "Append episode IDs to curated hero list (indexer auto-promote)",
+        request: { body: jsonBody(heroCurationAppendRequestSchema) },
+        responses: {
+            200: { description: "Hero curation after append", ...contentJson(heroCurationResponseSchema) },
             400: { description: "Bad request", ...contentJson(errorSchema) },
             ...serverErrorResponse,
             ...authResponses

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -70,7 +70,13 @@ export const discoveryScheduleResponseSchema = z.object({
  */
 export const heroCurationUpdateRequestSchema = z.object({
 	episodeIds: z.array(z.string().uuid()).optional(),
-	railSubjects: z.array(z.string().min(1).max(200)).optional()
+	railSubjects: z.array(z.string().min(1).max(200)).optional(),
+	expectedUpdatedAt: z.string().datetime({ offset: true }).optional().nullable()
+});
+
+/** POST /hero-curation/episodes — append episode IDs (indexer auto-promote). */
+export const heroCurationAppendRequestSchema = z.object({
+	episodeIds: z.array(z.string().uuid()).min(1)
 });
 
 /** GET/PUT /hero-curation — curated hero episode IDs and pinned rail subjects. */

--- a/src/pruneHeroCurationScheduled.ts
+++ b/src/pruneHeroCurationScheduled.ts
@@ -1,0 +1,65 @@
+import { Env } from "./Env";
+import { heroCurationStub } from "./HeroCurationDurableObject";
+
+type HomepagePayload = {
+	recentEpisodes?: Array<{ id?: string; subjects?: string[] }>;
+};
+
+/**
+ * Every 6h: drop curated hero IDs (and pinned rails) that left the homepage week window.
+ */
+export async function pruneHeroCurationScheduled(env: Env): Promise<void> {
+	let object: R2ObjectBody | null = null;
+	try {
+		object = await env.Content.get("homepage");
+	} catch (error) {
+		console.error("hero-prune: failed to read R2 homepage", error);
+		return;
+	}
+	if (!object) {
+		console.warn("hero-prune: homepage object missing; skip");
+		return;
+	}
+
+	let homepage: HomepagePayload;
+	try {
+		homepage = await object.json<HomepagePayload>();
+	} catch (error) {
+		console.error("hero-prune: invalid homepage JSON", error);
+		return;
+	}
+
+	const recent = Array.isArray(homepage.recentEpisodes) ? homepage.recentEpisodes : [];
+	const allowedEpisodeIds = recent
+		.map((ep) => ep.id)
+		.filter((id): id is string => typeof id === "string" && id.length > 0);
+
+	const allowedRailSubjects = new Set<string>();
+	for (const ep of recent) {
+		if (!Array.isArray(ep.subjects)) {
+			continue;
+		}
+		for (const subject of ep.subjects) {
+			if (typeof subject === "string" && subject.length > 0 && !subject.startsWith("_")) {
+				allowedRailSubjects.add(subject);
+			}
+		}
+	}
+
+	try {
+		const { state, pruned } = await heroCurationStub(env).pruneToAllowedIds(
+			allowedEpisodeIds,
+			[...allowedRailSubjects]
+		);
+		if (pruned) {
+			console.log(
+				`hero-prune: pruned to ${state.episodeIds.length} episodes, ${state.railSubjects.length} rails (updatedAt=${state.updatedAt})`
+			);
+		} else {
+			console.log("hero-prune: no changes");
+		}
+	} catch (error) {
+		console.error("hero-prune: Durable Object prune failed", error);
+	}
+}
+

--- a/tests/hero-curation.spec.ts
+++ b/tests/hero-curation.spec.ts
@@ -1,61 +1,76 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { dedupeAndCap, MAX_EPISODE_IDS, MAX_RAIL_SUBJECTS } from "../src/heroCurationLogic";
 
 /**
- * Source-contract checks for /hero-curation (GET public, PUT curate + KV).
+ * Source-contract checks for /hero-curation (GET public, PUT/POST curate + DO).
  */
 describe("hero-curation contract", () => {
 	const src = readFileSync(resolve(process.cwd(), "src/heroCuration.ts"), "utf8");
 	const routes = readFileSync(resolve(process.cwd(), "src/openapiRoutes.ts"), "utf8");
 	const index = readFileSync(resolve(process.cwd(), "src/index.ts"), "utf8");
+	const wrangler = readFileSync(resolve(process.cwd(), "wrangler.jsonc"), "utf8");
 
-	it("registers GET and PUT /hero-curation", () => {
+	it("registers GET, PUT, and POST append routes", () => {
 		expect(index).toContain("openapi.get('/hero-curation', GetHeroCurationRoute)");
 		expect(index).toContain("openapi.put('/hero-curation', PutHeroCurationRoute)");
+		expect(index).toContain("openapi.post('/hero-curation/episodes', AppendHeroCurationEpisodesRoute)");
 	});
 
-	it("GET is public; PUT requires Auth0 middleware", () => {
+	it("GET is public; PUT and POST require Auth0 middleware", () => {
 		const getBlock = routes.match(
 			/export const GetHeroCurationRoute = createOpenApiRoute\(getHeroCuration, \{[\s\S]*?\n\}\);/
 		)?.[0];
 		const putBlock = routes.match(
 			/export const PutHeroCurationRoute = createOpenApiRoute\(putHeroCuration, \{[\s\S]*?\n\}\);/
 		)?.[0];
+		const appendBlock = routes.match(
+			/export const AppendHeroCurationEpisodesRoute = createOpenApiRoute\(appendHeroCurationEpisodes, \{[\s\S]*?\n\}\);/
+		)?.[0];
 		expect(getBlock).toBeDefined();
 		expect(putBlock).toBeDefined();
+		expect(appendBlock).toBeDefined();
 		expect(getBlock).not.toContain("auth: true");
 		expect(putBlock).toContain("auth: true");
+		expect(appendBlock).toContain("auth: true");
 	});
 
-	it("PUT enforces curate permission with 401/403", () => {
+	it("mutations enforce curate permission with 401/403", () => {
 		expect(src).toContain("permissions?.includes(\"curate\")");
 		expect(src).toContain("401");
 		expect(src).toContain("403");
 		expect(src).toContain("400");
 	});
 
-	it("uses Curated KV key hero-episode-ids and GET cache max-age 60", () => {
-		expect(src).toContain("hero-episode-ids");
-		expect(src).toContain("Curated");
+	it("uses HeroCuration Durable Object and GET cache max-age 60", () => {
+		expect(src).toContain("heroCurationStub");
 		expect(src).toContain("cacheControlMaxAge: 60");
-		expect(src).toContain('episodeIds: []');
-		expect(src).toContain("railSubjects: []");
-		expect(src).toContain("updatedAt: null");
+		expect(src).toContain("updatedAt");
+		expect(wrangler).toContain("HeroCurationDurableObject");
+		expect(wrangler).toContain("HERO_CURATION_DURABLE_OBJECT");
+	});
+
+	it("schedules prune every 6 hours", () => {
+		expect(wrangler).toContain("0 */6 * * *");
+		expect(index).toContain("pruneHeroCurationScheduled");
+		expect(index).toContain("scheduled");
 	});
 
 	it("dedupes and caps episode IDs at 50 and rail subjects at 12", () => {
-		expect(src).toContain("MAX_EPISODE_IDS = 50");
-		expect(src).toContain("MAX_RAIL_SUBJECTS = 12");
-		expect(src).toContain("dedupeAndCap");
+		expect(MAX_EPISODE_IDS).toBe(50);
+		expect(MAX_RAIL_SUBJECTS).toBe(12);
+		expect(dedupeAndCap(["a", "a", "b"], 50)).toEqual(["a", "b"]);
+		expect(dedupeAndCap(Array.from({ length: 60 }, (_, i) => `id-${i}`), 50)).toHaveLength(50);
 	});
 
-	it("merges partial updates so hero-only or rails-only PUTs keep the other list", () => {
-		expect(src).toContain("existing?.episodeIds ?? []");
-		expect(src).toContain("existing?.railSubjects ?? []");
+	it("supports expectedUpdatedAt conflict responses", () => {
+		expect(src).toContain("expectedUpdatedAt");
+		expect(src).toContain("409");
 	});
 
 	it("rejects a PUT carrying neither episodeIds nor railSubjects", () => {
 		expect(src).toContain("!parsed.data.episodeIds && !parsed.data.railSubjects");
 	});
 });
+

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -46,6 +46,10 @@
       {
         "name": "PROFILE_DURABLE_OBJECT",
         "class_name": "ProfileDurableObject"
+      },
+      {
+        "name": "HERO_CURATION_DURABLE_OBJECT",
+        "class_name": "HeroCurationDurableObject"
       }
     ]
   },
@@ -66,6 +70,12 @@
       "tag": "v3",
       "new_sqlite_classes": [
         "ProfileDurableObject"
+      ]
+    },
+    {
+      "tag": "v4",
+      "new_sqlite_classes": [
+        "HeroCurationDurableObject"
       ]
     }
   ],
@@ -113,6 +123,10 @@
           {
             "name": "PROFILE_DURABLE_OBJECT",
             "class_name": "ProfileDurableObject"
+          },
+          {
+            "name": "HERO_CURATION_DURABLE_OBJECT",
+            "class_name": "HeroCurationDurableObject"
           }
         ]
       },
@@ -145,8 +159,19 @@
           "deleted_classes": [
             "ProfileDurableObjectLegacy"
           ]
+        },
+        {
+          "tag": "preview-v4",
+          "new_sqlite_classes": [
+            "HeroCurationDurableObject"
+          ]
         }
-      ]
+      ],
+      "triggers": {
+        "crons": [
+          "0 */6 * * *"
+        ]
+      }
     },
     "production": {
       // Same KV→SQLite cutover as preview if this named env was ever deployed.
@@ -194,6 +219,10 @@
           {
             "name": "PROFILE_DURABLE_OBJECT_LEGACY",
             "class_name": "ProfileDurableObjectLegacy"
+          },
+          {
+            "name": "HERO_CURATION_DURABLE_OBJECT",
+            "class_name": "HeroCurationDurableObject"
           }
         ]
       },
@@ -214,6 +243,12 @@
           ],
           "new_sqlite_classes": [
             "ProfileDurableObject"
+          ]
+        },
+        {
+          "tag": "production-v3",
+          "new_sqlite_classes": [
+            "HeroCurationDurableObject"
           ]
         }
       ]
@@ -258,6 +293,10 @@
           {
             "name": "PROFILE_DURABLE_OBJECT",
             "class_name": "ProfileDurableObject"
+          },
+          {
+            "name": "HERO_CURATION_DURABLE_OBJECT",
+            "class_name": "HeroCurationDurableObject"
           }
         ]
       },
@@ -266,6 +305,12 @@
           "tag": "local-v1",
           "new_sqlite_classes": [
             "ProfileDurableObject"
+          ]
+        },
+        {
+          "tag": "local-v2",
+          "new_sqlite_classes": [
+            "HeroCurationDurableObject"
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- Move homepage hero curation from KV to a SQLite `HeroCurationDurableObject` (wrangler migrations for top-level, preview, production, and local).
- Add `POST /hero-curation/episodes` for always-promote append, with OpenAPI schemas/routes and auto-promote logging.
- Wire a scheduled prune cron (every 6h on preview) via `pruneHeroCurationScheduled`.

## Notes
- Branched cleanly from `origin/main` (which already includes preview Profile DO SQLite #122). Working tree was previously on `fix/preview-profile-do-sqlite`; only hero-curation DO files were included — no Profile DO SQLite changes in this PR.
- Preview deploy was done separately; this PR does not deploy production.

## Test plan
- [ ] `npm test` / hero-curation specs pass
- [ ] GET/PUT `/hero-curation` against Durable Object storage
- [ ] POST `/hero-curation/episodes` appends and logs auto-promote
- [ ] Confirm wrangler migration tags apply on next preview/prod deploy (no prod deploy in this PR)

Made with [Cursor](https://cursor.com)