### PR TITLE
fix(api): accept curate from JWT permissions or scope

### DIFF
--- a/src/Auth0JwtPayload.ts
+++ b/src/Auth0JwtPayload.ts
@@ -2,6 +2,8 @@ import { JwtPayload } from '@cfworker/jwt';
 
 export interface Auth0JwtPayload extends JwtPayload {
     azp: string;
+    /** Present on some Auth0 M2M tokens instead of / alongside azp. */
+    client_id?: string;
     scope: string;
     permissions: string[];
 }

--- a/src/hasPermission.ts
+++ b/src/hasPermission.ts
@@ -1,0 +1,27 @@
+import { Auth0JwtPayload } from "./Auth0JwtPayload";
+
+/**
+ * True when the JWT grants `permission` via the RBAC `permissions` claim
+ * and/or the space-delimited OAuth `scope` claim.
+ *
+ * Auth0 M2M tokens always carry granted APIs in `scope`. The `permissions`
+ * array is only present when the API has "Add Permissions in Access Token"
+ * enabled (Auth0 Dashboard → APIs → api.cultpodcasts.com → Settings).
+ * Edge callers (client_credentials) must not be locked out if that toggle
+ * is off — hero auto-promote previously 403'd for that reason.
+ */
+export function hasPermission(
+	payload: Auth0JwtPayload | null | undefined,
+	permission: string
+): boolean {
+	if (!payload || !permission) {
+		return false;
+	}
+	if (payload.permissions?.includes(permission)) {
+		return true;
+	}
+	if (typeof payload.scope === "string" && payload.scope.length > 0) {
+		return payload.scope.split(/\s+/).includes(permission);
+	}
+	return false;
+}

--- a/src/heroCuration.ts
+++ b/src/heroCuration.ts
@@ -3,6 +3,7 @@ import { ActionContext } from "./ActionContext";
 import { Auth0ActionContext } from "./Auth0ActionContext";
 import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { hasPermission } from "./hasPermission";
+import { formatCurateAuthzClaims } from "./jwtAuthzLog";
 import { LogCollector } from "./LogCollector";
 import {
 	heroCurationAppendRequestSchema,
@@ -13,12 +14,16 @@ import { heroCurationStub } from "./HeroCurationDurableObject";
 function requireCurate(c: Auth0ActionContext, logCollector: LogCollector): Response | null {
 	const auth0Payload: Auth0JwtPayload = c.var.auth0("payload");
 	if (!auth0Payload) {
-		logCollector.addMessage("Unauthorised to mutate hero curation.");
+		logCollector.addMessage(
+			`Hero curation authz 401: missing or invalid Auth0 payload. ${formatCurateAuthzClaims(null)}`
+		);
 		console.error(logCollector.toEndpointLog());
 		return c.json({ error: "Unauthorised" }, 401);
 	}
 	if (!hasPermission(auth0Payload, "curate")) {
-		logCollector.addMessage("Forbidden to mutate hero curation.");
+		logCollector.addMessage(
+			`Hero curation authz 403: missing curate. ${formatCurateAuthzClaims(auth0Payload)}`
+		);
 		console.error(logCollector.toEndpointLog());
 		return c.json({ error: "Forbidden" }, 403);
 	}

--- a/src/heroCuration.ts
+++ b/src/heroCuration.ts
@@ -2,6 +2,7 @@ import { AddResponseHeaders } from "./AddResponseHeaders";
 import { ActionContext } from "./ActionContext";
 import { Auth0ActionContext } from "./Auth0ActionContext";
 import { Auth0JwtPayload } from "./Auth0JwtPayload";
+import { hasPermission } from "./hasPermission";
 import { LogCollector } from "./LogCollector";
 import {
 	heroCurationAppendRequestSchema,
@@ -16,7 +17,7 @@ function requireCurate(c: Auth0ActionContext, logCollector: LogCollector): Respo
 		console.error(logCollector.toEndpointLog());
 		return c.json({ error: "Unauthorised" }, 401);
 	}
-	if (!auth0Payload.permissions?.includes("curate")) {
+	if (!hasPermission(auth0Payload, "curate")) {
 		logCollector.addMessage("Forbidden to mutate hero curation.");
 		console.error(logCollector.toEndpointLog());
 		return c.json({ error: "Forbidden" }, 403);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { getCookie, setCookie } from 'hono/cookie';
 import { cors } from 'hono/cors'
 import { Env } from './Env';
 import { Auth0JwtPayload } from './Auth0JwtPayload';
+import { hasPermission } from './hasPermission';
 import { corsOptions } from "./corsOptions";
 import { ProfileDurableObject } from './ProfileDurableObject';
 import { ProfileDurableObjectLegacy } from './ProfileDurableObjectLegacy';
@@ -110,7 +111,7 @@ const getBearerToken = (c: any): string | undefined => {
 };
 
 const isAdmin = (payload: Auth0JwtPayload | null): boolean => {
-	return !!payload?.permissions?.includes('admin');
+	return hasPermission(payload, 'admin');
 };
 
 const isOpenApiAuthBypassPath = (pathname: string): boolean => {

--- a/src/jwtAuthzLog.ts
+++ b/src/jwtAuthzLog.ts
@@ -1,0 +1,57 @@
+import { Auth0JwtPayload } from "./Auth0JwtPayload";
+
+const AUD_MAX = 120;
+
+function truncate(value: string | undefined, max = AUD_MAX): string {
+	if (value == null || value === "") {
+		return "(none)";
+	}
+	if (value.length <= max) {
+		return value;
+	}
+	return `${value.slice(0, max)}…(len=${value.length})`;
+}
+
+function formatAud(aud: string | string[] | undefined): string {
+	if (aud == null) {
+		return "(none)";
+	}
+	if (Array.isArray(aud)) {
+		return truncate(JSON.stringify(aud));
+	}
+	return truncate(aud);
+}
+
+/**
+ * Safe JWT claim summary for curate authz failures.
+ * Never include the raw Bearer token or signature.
+ */
+export function formatCurateAuthzClaims(
+	payload: Auth0JwtPayload | null | undefined,
+	permission = "curate"
+): string {
+	if (!payload) {
+		return "reason=missing_or_invalid_token";
+	}
+
+	const permissions = Array.isArray(payload.permissions) ? payload.permissions : [];
+	const scope = typeof payload.scope === "string" ? payload.scope : "";
+	const scopeParts = scope.length > 0 ? scope.split(/\s+/).filter(Boolean) : [];
+	const inPermissions = permissions.includes(permission);
+	const inScope = scopeParts.includes(permission);
+	const azp =
+		(typeof payload.azp === "string" && payload.azp) ||
+		(typeof payload.client_id === "string" && payload.client_id) ||
+		"(none)";
+
+	return [
+		`sub=${payload.sub ?? "(none)"}`,
+		`azp=${azp}`,
+		`permissions=${JSON.stringify(permissions)}`,
+		`scope=${JSON.stringify(scope)}`,
+		`${permission}InPermissions=${inPermissions}`,
+		`${permission}InScope=${inScope}`,
+		`iss=${truncate(payload.iss)}`,
+		`aud=${formatAud(payload.aud)}`
+	].join(" ");
+}

--- a/src/proxyToAzure.ts
+++ b/src/proxyToAzure.ts
@@ -3,6 +3,7 @@ import { Auth0JwtPayload } from "./Auth0JwtPayload";
 import { buildFetchHeaders } from "./buildFetchHeaders";
 import { Endpoint } from "./Endpoint";
 import { getEndpoint } from "./endpoints";
+import { hasPermission } from "./hasPermission";
 import { LogCollector } from "./LogCollector";
 
 export type ProxyToAzureOptions = {
@@ -41,9 +42,7 @@ export async function proxyToAzure(
 
 	const permitted =
 		auth0Payload != null &&
-		(opts.permission == null ||
-			(auth0Payload.permissions != null &&
-				auth0Payload.permissions.includes(opts.permission)));
+		(opts.permission == null || hasPermission(auth0Payload, opts.permission));
 
 	try {
 		if (permitted) {

--- a/src/proxyToAzure.ts
+++ b/src/proxyToAzure.ts
@@ -4,6 +4,7 @@ import { buildFetchHeaders } from "./buildFetchHeaders";
 import { Endpoint } from "./Endpoint";
 import { getEndpoint } from "./endpoints";
 import { hasPermission } from "./hasPermission";
+import { formatCurateAuthzClaims } from "./jwtAuthzLog";
 import { LogCollector } from "./LogCollector";
 
 export type ProxyToAzureOptions = {
@@ -95,12 +96,20 @@ export async function proxyToAzure(
 	}
 
 	if (!auth0Payload) {
-		logCollector.addMessage(`Unauthorised to use ${opts.logName}.`);
+		const detail =
+			opts.permission === "curate"
+				? ` ${formatCurateAuthzClaims(null)}`
+				: "";
+		logCollector.addMessage(`Unauthorised to use ${opts.logName}.${detail}`);
 		console.error(logCollector.toEndpointLog());
 		return c.json({ error: "Unauthorised" }, 401);
 	}
 
-	logCollector.addMessage(`Forbidden to use ${opts.logName}.`);
+	const detail =
+		opts.permission === "curate"
+			? ` missing ${opts.permission}. ${formatCurateAuthzClaims(auth0Payload, opts.permission)}`
+			: "";
+	logCollector.addMessage(`Forbidden to use ${opts.logName}.${detail}`);
 	console.error(logCollector.toEndpointLog());
 	return c.json({ error: "Forbidden" }, 403);
 }

--- a/src/proxyToAzure.ts
+++ b/src/proxyToAzure.ts
@@ -4,7 +4,6 @@ import { buildFetchHeaders } from "./buildFetchHeaders";
 import { Endpoint } from "./Endpoint";
 import { getEndpoint } from "./endpoints";
 import { hasPermission } from "./hasPermission";
-import { formatCurateAuthzClaims } from "./jwtAuthzLog";
 import { LogCollector } from "./LogCollector";
 
 export type ProxyToAzureOptions = {
@@ -96,20 +95,12 @@ export async function proxyToAzure(
 	}
 
 	if (!auth0Payload) {
-		const detail =
-			opts.permission === "curate"
-				? ` ${formatCurateAuthzClaims(null)}`
-				: "";
-		logCollector.addMessage(`Unauthorised to use ${opts.logName}.${detail}`);
+		logCollector.addMessage(`Unauthorised to use ${opts.logName}.`);
 		console.error(logCollector.toEndpointLog());
 		return c.json({ error: "Unauthorised" }, 401);
 	}
 
-	const detail =
-		opts.permission === "curate"
-			? ` missing ${opts.permission}. ${formatCurateAuthzClaims(auth0Payload, opts.permission)}`
-			: "";
-	logCollector.addMessage(`Forbidden to use ${opts.logName}.${detail}`);
+	logCollector.addMessage(`Forbidden to use ${opts.logName}.`);
 	console.error(logCollector.toEndpointLog());
 	return c.json({ error: "Forbidden" }, 403);
 }

--- a/tests/hasPermission.spec.ts
+++ b/tests/hasPermission.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { hasPermission } from "../src/hasPermission";
+import type { Auth0JwtPayload } from "../src/Auth0JwtPayload";
+
+function payload(partial: Partial<Auth0JwtPayload>): Auth0JwtPayload {
+	return partial as Auth0JwtPayload;
+}
+
+describe("hasPermission", () => {
+	it("accepts curate from permissions claim", () => {
+		expect(hasPermission(payload({ permissions: ["curate"] }), "curate")).toBe(true);
+	});
+
+	it("accepts curate from space-delimited scope when permissions absent", () => {
+		expect(hasPermission(payload({ scope: "curate" }), "curate")).toBe(true);
+		expect(hasPermission(payload({ scope: "openid curate profile" }), "curate")).toBe(true);
+	});
+
+	it("rejects when neither permissions nor scope grants the permission", () => {
+		expect(hasPermission(payload({ scope: "openid profile", permissions: ["submit"] }), "curate")).toBe(false);
+		expect(hasPermission(null, "curate")).toBe(false);
+		expect(hasPermission(payload({}), "curate")).toBe(false);
+	});
+});

--- a/tests/hero-curation.spec.ts
+++ b/tests/hero-curation.spec.ts
@@ -37,10 +37,16 @@ describe("hero-curation contract", () => {
 	});
 
 	it("mutations enforce curate permission with 401/403", () => {
-		expect(src).toContain("permissions?.includes(\"curate\")");
+		expect(src).toContain('hasPermission(auth0Payload, "curate")');
 		expect(src).toContain("401");
 		expect(src).toContain("403");
 		expect(src).toContain("400");
+	});
+
+	it("accepts curate from permissions or OAuth scope (M2M)", () => {
+		const helper = readFileSync(resolve(process.cwd(), "src/hasPermission.ts"), "utf8");
+		expect(helper).toContain("permissions?.includes");
+		expect(helper).toContain("scope.split");
 	});
 
 	it("uses HeroCuration Durable Object and GET cache max-age 60", () => {

--- a/tests/hero-curation.spec.ts
+++ b/tests/hero-curation.spec.ts
@@ -43,6 +43,17 @@ describe("hero-curation contract", () => {
 		expect(src).toContain("400");
 	});
 
+	it("logs safe JWT claims on requireCurate 401/403", () => {
+		expect(src).toContain("formatCurateAuthzClaims");
+		expect(src).toContain("Hero curation authz 401");
+		expect(src).toContain("Hero curation authz 403");
+		const helper = readFileSync(resolve(process.cwd(), "src/jwtAuthzLog.ts"), "utf8");
+		expect(helper).toContain("permissions=");
+		expect(helper).toContain("scope=");
+		expect(helper).not.toContain("authorization.slice");
+		expect(helper).not.toContain("c.req.header");
+	});
+
 	it("accepts curate from permissions or OAuth scope (M2M)", () => {
 		const helper = readFileSync(resolve(process.cwd(), "src/hasPermission.ts"), "utf8");
 		expect(helper).toContain("permissions?.includes");

--- a/tests/jwtAuthzLog.spec.ts
+++ b/tests/jwtAuthzLog.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { formatCurateAuthzClaims } from "../src/jwtAuthzLog";
+import type { Auth0JwtPayload } from "../src/Auth0JwtPayload";
+
+function payload(partial: Partial<Auth0JwtPayload>): Auth0JwtPayload {
+	return partial as Auth0JwtPayload;
+}
+
+describe("formatCurateAuthzClaims", () => {
+	it("reports missing token without dumping secrets", () => {
+		const msg = formatCurateAuthzClaims(null);
+		expect(msg).toBe("reason=missing_or_invalid_token");
+		expect(msg).not.toMatch(/Bearer|eyJ|signature/i);
+	});
+
+	it("surfaces permissions, scope, and curate presence flags for 403 diagnosis", () => {
+		const msg = formatCurateAuthzClaims(
+			payload({
+				sub: "client@clients",
+				azp: "m2m-client-id",
+				permissions: ["submit"],
+				scope: "openid profile",
+				iss: "https://auth.example.com/",
+				aud: "https://api.cultpodcasts.com"
+			})
+		);
+		expect(msg).toContain("sub=client@clients");
+		expect(msg).toContain("azp=m2m-client-id");
+		expect(msg).toContain('permissions=["submit"]');
+		expect(msg).toContain('scope="openid profile"');
+		expect(msg).toContain("curateInPermissions=false");
+		expect(msg).toContain("curateInScope=false");
+		expect(msg).toContain("iss=https://auth.example.com/");
+		expect(msg).toContain("aud=https://api.cultpodcasts.com");
+		expect(msg).not.toMatch(/Bearer |eyJ[A-Za-z0-9_-]/);
+	});
+
+	it("falls back to client_id when azp absent and flags curate in scope", () => {
+		const msg = formatCurateAuthzClaims(
+			payload({
+				sub: "m2m@clients",
+				client_id: "edge-client",
+				scope: "openid curate",
+				iss: "https://auth.example.com/",
+				aud: ["https://api.cultpodcasts.com"]
+			})
+		);
+		expect(msg).toContain("azp=edge-client");
+		expect(msg).toContain("curateInPermissions=false");
+		expect(msg).toContain("curateInScope=true");
+	});
+
+	it("truncates oversized aud arrays", () => {
+		const huge = Array.from({ length: 40 }, (_, i) => `aud-${i}-${"x".repeat(20)}`);
+		const msg = formatCurateAuthzClaims(
+			payload({
+				sub: "u",
+				azp: "c",
+				permissions: ["curate"],
+				scope: "curate",
+				iss: "https://iss.example/",
+				aud: huge
+			})
+		);
+		expect(msg).toContain("aud=");
+		expect(msg).toMatch(/…\(len=\d+\)/);
+		expect(msg).toContain("curateInPermissions=true");
+		expect(msg).toContain("curateInScope=true");
+	});
+});


### PR DESCRIPTION
## Summary
- Hero auto-promote (`POST /hero-curation/episodes`) returned **403** when the Edge M2M JWT had `scope: curate` but no `permissions` array — `requireCurate` only checked `permissions`.
- Add shared `hasPermission()` that accepts the grant from **permissions or space-delimited scope**; use it in hero curation, `proxyToAzure`, and OpenAPI admin gate.
- Defense in depth if Auth0 API setting **Add Permissions in Access Token** is off (Dashboard → APIs → `https://api.cultpodcasts.com/` → Settings). That toggle is currently **on** for Edge M2M (`permissions: ["curate"]` present).

## Context
Discovery create for episode `b965553c-69ad-4b56-975e-de0189a97a05` at ~15:01 UTC 2026-07-27 hit Edge with 403. Current Edge M2M (KV `Auth0-ClientId` `MRPNIzrc…`) now includes both `scope` and `permissions`; empty-body probe returns 400 (auth OK). `Auth0Client` does **not** cache tokens.

## Test plan
- [x] `npm test -- tests/hasPermission.spec.ts tests/hero-curation.spec.ts`
- [x] `tsc --noEmit`
- [ ] After deploy: M2M POST `/hero-curation/episodes` with valid body succeeds (200) when JWT has either claim shape
- [ ] SPA curator PUT `/hero-curation` still works (permissions claim)