### PR TITLE
feat(api): create shortener KV with share image on page-details miss

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/ShortnerRecord.ts
+++ b/src/ShortnerRecord.ts
@@ -1,5 +1,16 @@
+import { EpisodeShareImageAspect } from "./episodeShareImage";
+
 export interface ShortnerRecord {
     episodeTitle?: string;
     releaseDate?: string;
     duration?: string;
+    /**
+     * Search-index image encoding (y{q} / s{id} / a{n}{path} / full URL).
+     * Expanded to an absolute URL when serving page-details.
+     */
+    image?: string;
+    /** Required to expand YouTube y{q} tokens. */
+    youtubeId?: string;
+    /** YouTube / BBC iPlayer / Internet Archive → wide; Spotify/Apple/BBC Sounds → square. */
+    imageAspect?: EpisodeShareImageAspect;
 }

--- a/src/episodeShareImage.ts
+++ b/src/episodeShareImage.ts
@@ -1,0 +1,188 @@
+/**
+ * Share-preview image helpers.
+ * Search-index `image` uses SearchEpisodeImage compaction (y{q} / s{id} / a{n}{path} / full URL).
+ * KV shortener metadata stores that encoding + youtubeId; page-details expands to an absolute
+ * HTTPS URL for og:image / twitter:image.
+ *
+ * Aspect for twitter:card:
+ * - YouTube / BBC iPlayer / Internet Archive → wide (summary_large_image)
+ * - Spotify / Apple / BBC Sounds → square (summary)
+ */
+
+const youtubeQualityByCode: Record<string, string> = {
+	x: "maxresdefault",
+	s: "sddefault",
+	h: "hqdefault",
+	m: "mqdefault",
+	d: "default"
+};
+
+export type EpisodeShareImageAspect = "wide" | "square";
+
+export type EpisodeShareImage = {
+	/** Absolute HTTPS URL for social crawlers. */
+	image: string;
+	imageAspect: EpisodeShareImageAspect;
+};
+
+/** Fields persisted on shortener KV (search-index encoding, not absolute URL). */
+export type EpisodeShareImageStorage = {
+	/** Search-index image token or full URL (same as Azure Search `image`). */
+	image: string;
+	youtubeId?: string;
+	imageAspect: EpisodeShareImageAspect;
+};
+
+export type SearchEpisodeImageFields = {
+	image?: string | null;
+	youtubeId?: string | null;
+	bbc?: string | null;
+	internetArchive?: string | null;
+};
+
+/** Loss-less inverse of SearchEpisodeImage compaction (mirrors website expandImage). */
+export function expandSearchImage(
+	image: string | undefined | null,
+	youtubeId: string | undefined | null
+): string | undefined {
+	if (!image) {
+		return undefined;
+	}
+	if (image.startsWith("http")) {
+		return image;
+	}
+
+	const payload = image.slice(1);
+	switch (image[0]) {
+		case "y": {
+			const quality = youtubeQualityByCode[payload];
+			return quality && youtubeId
+				? `https://i.ytimg.com/vi/${encodeURIComponent(youtubeId)}/${quality}.jpg`
+				: undefined;
+		}
+		case "s":
+			return payload ? `https://i.scdn.co/image/${payload}` : undefined;
+		case "a":
+			return payload
+				? `https://is${payload[0]}-ssl.mzstatic.com/image/thumb/${payload.slice(1)}`
+				: undefined;
+		default:
+			return undefined;
+	}
+}
+
+function isYoutubeThumbnailTokenOrUrl(image: string | undefined): boolean {
+	if (!image) {
+		return false;
+	}
+	if (image.length >= 2 && image[0] === "y" && image[1] in youtubeQualityByCode) {
+		return true;
+	}
+	try {
+		return new URL(image).hostname === "i.ytimg.com";
+	} catch {
+		return false;
+	}
+}
+
+function youtubeThumbnailUrl(youtubeId: string): string {
+	return `https://i.ytimg.com/vi/${encodeURIComponent(youtubeId)}/hqdefault.jpg`;
+}
+
+/** Mirrors website BBCServiceResolver.isIplayer (video → wide card). */
+function isBbcIplayerUrl(value: string | null | undefined): boolean {
+	if (!value) {
+		return false;
+	}
+	try {
+		const url = new URL(value);
+		const host = url.hostname;
+		const isBbc = host.endsWith("bbc.com") || host.endsWith("bbc.co.uk");
+		return isBbc && (url.pathname.startsWith("/iplayer/") || url.pathname.startsWith("/news/av-embeds/"));
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Display URL for share previews — mirrors website episodeImageUrl for search hits:
+ * prefer YouTube frame when youtubeId is set; else expand the search-index image value.
+ */
+export function resolveShareImageAbsoluteUrl(episode: SearchEpisodeImageFields): string | undefined {
+	if (isYoutubeThumbnailTokenOrUrl(episode.image ?? undefined)) {
+		return expandSearchImage(episode.image, episode.youtubeId);
+	}
+	if (episode.youtubeId) {
+		return youtubeThumbnailUrl(episode.youtubeId);
+	}
+	return expandSearchImage(episode.image, episode.youtubeId);
+}
+
+export function resolveShareImageAspect(
+	absoluteImage: string,
+	episode: SearchEpisodeImageFields
+): EpisodeShareImageAspect {
+	if (isYoutubeThumbnailTokenOrUrl(absoluteImage) || episode.youtubeId) {
+		return "wide";
+	}
+	if (isBbcIplayerUrl(episode.bbc) || episode.internetArchive) {
+		return "wide";
+	}
+	return "square";
+}
+
+/** Absolute image URL + card aspect for crawlers / page-details response. */
+export function resolveEpisodeShareImage(episode: SearchEpisodeImageFields): EpisodeShareImage | undefined {
+	const absolute = resolveShareImageAbsoluteUrl(episode);
+	if (!absolute) {
+		return undefined;
+	}
+	return {
+		image: absolute,
+		imageAspect: resolveShareImageAspect(absolute, episode)
+	};
+}
+
+/**
+ * What to persist on shortener KV: search-index `image` encoding (+ youtubeId for y{q} expand).
+ * Falls back to absolute URL only when there is no search image but youtubeId still yields a frame.
+ */
+export function toShareImageStorage(episode: SearchEpisodeImageFields): EpisodeShareImageStorage | undefined {
+	const absolute = resolveShareImageAbsoluteUrl(episode);
+	if (!absolute) {
+		return undefined;
+	}
+	const imageAspect = resolveShareImageAspect(absolute, episode);
+	const searchImage = episode.image?.trim();
+	if (searchImage) {
+		return {
+			image: searchImage,
+			youtubeId: episode.youtubeId || undefined,
+			imageAspect
+		};
+	}
+	// Invented YouTube hqdefault when index had no image — store absolute (not a search token).
+	return {
+		image: absolute,
+		youtubeId: episode.youtubeId || undefined,
+		imageAspect
+	};
+}
+
+/** Expand KV/search storage back to absolute share URL (+ aspect). */
+export function shareImageFromStorage(stored: {
+	image?: string | null;
+	youtubeId?: string | null;
+	imageAspect?: EpisodeShareImageAspect | null;
+	bbc?: string | null;
+	internetArchive?: string | null;
+}): EpisodeShareImage | undefined {
+	const absolute = resolveShareImageAbsoluteUrl(stored);
+	if (!absolute) {
+		return undefined;
+	}
+	return {
+		image: absolute,
+		imageAspect: stored.imageAspect ?? resolveShareImageAspect(absolute, stored)
+	};
+}

--- a/src/episodeShareImage.ts
+++ b/src/episodeShareImage.ts
@@ -186,3 +186,44 @@ export function shareImageFromStorage(stored: {
 		imageAspect: stored.imageAspect ?? resolveShareImageAspect(absolute, stored)
 	};
 }
+
+/** Logo drawn onto episode art for OG cards (production site asset). */
+export const DEFAULT_OG_LOGO_URL = "https://cultpodcasts.com/assets/sq-image.png";
+
+const ALLOWED_SHARE_IMAGE_HOST_SUFFIXES = [
+	"i.ytimg.com",
+	"i.scdn.co",
+	"mzstatic.com",
+	"archive.org",
+	"bbci.co.uk",
+	"bbcimg.co.uk",
+	"bbc.co.uk",
+	"staticflickr.com"
+];
+
+export function isAllowedShareImageSourceHost(hostname: string): boolean {
+	const host = hostname.toLowerCase();
+	return ALLOWED_SHARE_IMAGE_HOST_SUFFIXES.some(
+		(suffix) => host === suffix || host.endsWith(`.${suffix}`)
+	);
+}
+
+export function parseOgImageAspect(value: string | undefined | null): EpisodeShareImageAspect {
+	return value === "wide" ? "wide" : "square";
+}
+
+/**
+ * Page-details `image` for crawlers: Api Worker URL that overlays the logo via CF Images.
+ * Falls back to the raw source if the Worker cannot transform (handled at /og-image).
+ */
+export function buildBrandedOgImageUrl(
+	apiRequestUrl: string,
+	sourceImageAbsoluteUrl: string,
+	aspect: EpisodeShareImageAspect = "square"
+): string {
+	const origin = new URL(apiRequestUrl).origin;
+	const url = new URL("/og-image", origin);
+	url.searchParams.set("u", sourceImageAbsoluteUrl);
+	url.searchParams.set("a", aspect);
+	return url.toString();
+}

--- a/src/getPageDetails.ts
+++ b/src/getPageDetails.ts
@@ -5,6 +5,24 @@ import { GuidService } from "./guid-service";
 import { IPageDetails } from "./ipage-details";
 import { ShortnerRecord } from "./ShortnerRecord";
 import { AddResponseHeaders } from "./AddResponseHeaders";
+import { shareImageFromStorage, toShareImageStorage } from "./episodeShareImage";
+
+/**
+ * Page-details for SSR / OG tags.
+ * - Existing shortener KV: never rewrite; use image for og:image only if already on the record.
+ * - Missing KV: fall back to search, create the record (incl. search-index image encoding), then use it.
+ */
+function pageDetailsFromKv(podcastName: string, meta: ShortnerRecord): IPageDetails {
+    const share = shareImageFromStorage(meta);
+    return {
+        description: podcastName,
+        title: `${meta.episodeTitle} | ${podcastName}`,
+        releaseDate: meta.releaseDate,
+        duration: meta.duration,
+        image: share?.image,
+        imageAspect: share?.imageAspect ?? meta.imageAspect
+    };
+}
 
 export async function getPageDetails(c: ActionContext): Promise<Response> {
     const logCollector = new LogCollector();
@@ -15,90 +33,85 @@ export async function getPageDetails(c: ActionContext): Promise<Response> {
         methods: ["GET", "OPTIONS"]
     });
     const episodeId = c.req.param('episodeId');
-    const podcastName = decodeURIComponent(c.req.param('podcastName')??"");
-    if (episodeId && podcastName) {
-        const key = new GuidService().toBase64(episodeId);
-        let foundInKv: boolean = false;
-        const episodeKvWithMetaData = await c.env.shortner.getWithMetadata<ShortnerRecord>(key);
-        if (episodeKvWithMetaData != null && episodeKvWithMetaData.metadata != null) {
-            foundInKv = true;
-            var episodeTitle = episodeKvWithMetaData.metadata.episodeTitle;
-            if (episodeTitle) {
-                var pagedetails: IPageDetails = {
-                    description: podcastName,
-                    title: `${episodeTitle} | ${podcastName}`,
-                    releaseDate: episodeKvWithMetaData.metadata.releaseDate,
-                    duration: episodeKvWithMetaData.metadata.duration
-                };
-                logCollector.addMessage(`Found kv-meta-data with key '${key}'. podcast-name: '${podcastName}', episode-title: '${episodeTitle}', episode-id: '${episodeId}'.`);
-                console.log(logCollector.toEndpointLog());
-                return c.json(pagedetails);
-            } else {
-                logCollector.addMessage(`Missing kv-meta-data with key '${key}', episode-id '${episodeId}'.`);
-                console.error(logCollector.toEndpointLog());
-                return c.text(logCollector.message!, 400);
-            }
-        } else {
-            const search: oDataSearchModel = {
-                search: "",
-                filter: `(podcastName eq '${podcastName.replaceAll("'", "''")}') and (id eq '${episodeId}')`,
-                orderby: "release desc",
-                skip: "0"
-            }
-            let requestBody = JSON.stringify(search);
-            const url = `${c.env.apihost}`;
-            let response = await fetch(url, {
-                cf: {
-                    cacheEverything: true,
-                    cacheTtl: 600
-                },
-                headers: {
-                    "api-key": c.env.apikey,
-                    "content-type": "application/json;charset=UTF-8",
-                },
-                body: requestBody,
-                method: "POST"
-            });
-            if (response.status == 200) {
-                const searchJson = await response.json<any>();
-                if (searchJson.value && searchJson.value.length == 1) {
-                    const episode = searchJson.value[0];
-                    const dateComponents = (episode.release as string).split("T")[0].split("-");
-                    const releaseDate = `${dateComponents[2]}/${dateComponents[1]}/${dateComponents[0]}`;
-                    var shortnerRecord: ShortnerRecord = {
-                        episodeTitle: episode.episodeTitle,
-                        releaseDate: releaseDate,
-                        duration: episode.duration
-                    };
-                    logCollector.addMessage("Found item-in-search");
-                    const encodedPodcastName =
-                        encodeURIComponent(podcastName)
-                            .replaceAll("(", "%28")
-                            .replaceAll(")", "%29");
-                    await c.env.shortner.put(key, `${encodedPodcastName}/${episodeId}`, { metadata: shortnerRecord })
-                    logCollector.addMessage(`Stored item in kv with key '${key}'`);
-                    console.log(logCollector.toEndpointLog());
-                    var pagedetails: IPageDetails = {
-                        description: podcastName,
-                        title: `${episode.episodeTitle} | ${podcastName}`,
-                        releaseDate: releaseDate,
-                        duration: episode.duration
-                    };
-                    return Response.json(pagedetails);
-                } else {
-                    logCollector.addMessage(`No item for episode-uuid '${episodeId}' and podcast-name '${podcastName}'`);
-                    console.error(logCollector.toEndpointLog());
-                    return c.text(logCollector.message!, 400);
-                }
-            } else {
-                logCollector.addMessage(`Search-api responded with status '${response.status}'`);
-                console.error(logCollector.toEndpointLog());
-                return c.text(logCollector.message!, 400);
-            }
-        }
-    } else {
+    const podcastName = decodeURIComponent(c.req.param('podcastName') ?? "");
+    if (!episodeId || !podcastName) {
         logCollector.addMessage(`Missing episode-id or podcast-name from request to api. Podcast-name: '${podcastName}', episode-id '${episodeId}'`);
         console.error(logCollector.toEndpointLog());
         return c.text(logCollector.message!, 400);
     }
+
+    const key = new GuidService().toBase64(episodeId);
+    const episodeKvWithMetaData = await c.env.shortner.getWithMetadata<ShortnerRecord>(key);
+    const kvMeta = episodeKvWithMetaData?.metadata;
+    const kvTitle = kvMeta?.episodeTitle;
+    const kvExists = episodeKvWithMetaData != null && episodeKvWithMetaData.value != null;
+
+    if (kvExists && kvTitle && kvMeta) {
+        logCollector.addMessage(`Found kv-meta-data with key '${key}'. podcast-name: '${podcastName}', episode-title: '${kvTitle}', episode-id: '${episodeId}', hasShareImage=${!!shareImageFromStorage(kvMeta)}.`);
+        console.log(logCollector.toEndpointLog());
+        return c.json(pageDetailsFromKv(podcastName, kvMeta));
+    }
+
+    if (kvExists) {
+        logCollector.addMessage(`KV key '${key}' exists but metadata incomplete; leaving unchanged and not recreating.`);
+        if (kvMeta) {
+            console.log(logCollector.toEndpointLog());
+            return c.json(pageDetailsFromKv(podcastName, kvMeta));
+        }
+        console.error(logCollector.toEndpointLog());
+        return c.text(logCollector.message!, 400);
+    }
+
+    const search: oDataSearchModel = {
+        search: "",
+        filter: `(podcastName eq '${podcastName.replaceAll("'", "''")}') and (id eq '${episodeId}')`,
+        orderby: "release desc",
+        skip: "0"
+    };
+    const response = await fetch(`${c.env.apihost}`, {
+        cf: {
+            cacheEverything: true,
+            cacheTtl: 600
+        },
+        headers: {
+            "api-key": c.env.apikey,
+            "content-type": "application/json;charset=UTF-8",
+        },
+        body: JSON.stringify(search),
+        method: "POST"
+    });
+
+    if (response.status == 200) {
+        const searchJson = await response.json<any>();
+        if (searchJson.value && searchJson.value.length == 1) {
+            const episode = searchJson.value[0];
+            const dateComponents = (episode.release as string).split("T")[0].split("-");
+            const releaseDate = `${dateComponents[2]}/${dateComponents[1]}/${dateComponents[0]}`;
+            const storage = toShareImageStorage(episode);
+            const shortnerRecord: ShortnerRecord = {
+                episodeTitle: episode.episodeTitle,
+                releaseDate: releaseDate,
+                duration: episode.duration,
+                image: storage?.image,
+                youtubeId: storage?.youtubeId,
+                imageAspect: storage?.imageAspect
+            };
+            logCollector.addMessage("Found item-in-search; creating new shortener KV (incl. share image when available).");
+            const encodedPodcastName =
+                encodeURIComponent(podcastName)
+                    .replaceAll("(", "%28")
+                    .replaceAll(")", "%29");
+            await c.env.shortner.put(key, `${encodedPodcastName}/${episodeId}`, { metadata: shortnerRecord });
+            logCollector.addMessage(`Stored kv item with key '${key}'`);
+            console.log(logCollector.toEndpointLog());
+            return Response.json(pageDetailsFromKv(podcastName, shortnerRecord));
+        }
+        logCollector.addMessage(`No item for episode-uuid '${episodeId}' and podcast-name '${podcastName}'`);
+        console.error(logCollector.toEndpointLog());
+        return c.text(logCollector.message!, 400);
+    }
+
+    logCollector.addMessage(`Search-api responded with status '${response.status}'`);
+    console.error(logCollector.toEndpointLog());
+    return c.text(logCollector.message!, 400);
 }

--- a/src/getPageDetails.ts
+++ b/src/getPageDetails.ts
@@ -5,21 +5,29 @@ import { GuidService } from "./guid-service";
 import { IPageDetails } from "./ipage-details";
 import { ShortnerRecord } from "./ShortnerRecord";
 import { AddResponseHeaders } from "./AddResponseHeaders";
-import { shareImageFromStorage, toShareImageStorage } from "./episodeShareImage";
+import {
+    buildBrandedOgImageUrl,
+    shareImageFromStorage,
+    toShareImageStorage
+} from "./episodeShareImage";
 
 /**
  * Page-details for SSR / OG tags.
  * - Existing shortener KV: never rewrite; use image for og:image only if already on the record.
  * - Missing KV: fall back to search, create the record (incl. search-index image encoding), then use it.
+ * - When an image exists, `image` is the Api `/og-image` Worker URL (CF logo overlay + Free-tier fallback).
  */
-function pageDetailsFromKv(podcastName: string, meta: ShortnerRecord): IPageDetails {
+function pageDetailsFromKv(podcastName: string, meta: ShortnerRecord, requestUrl: string): IPageDetails {
     const share = shareImageFromStorage(meta);
+    const image = share?.image
+        ? buildBrandedOgImageUrl(requestUrl, share.image, share.imageAspect)
+        : undefined;
     return {
         description: podcastName,
         title: `${meta.episodeTitle} | ${podcastName}`,
         releaseDate: meta.releaseDate,
         duration: meta.duration,
-        image: share?.image,
+        image,
         imageAspect: share?.imageAspect ?? meta.imageAspect
     };
 }
@@ -45,18 +53,19 @@ export async function getPageDetails(c: ActionContext): Promise<Response> {
     const kvMeta = episodeKvWithMetaData?.metadata;
     const kvTitle = kvMeta?.episodeTitle;
     const kvExists = episodeKvWithMetaData != null && episodeKvWithMetaData.value != null;
+    const requestUrl = c.req.url;
 
     if (kvExists && kvTitle && kvMeta) {
         logCollector.addMessage(`Found kv-meta-data with key '${key}'. podcast-name: '${podcastName}', episode-title: '${kvTitle}', episode-id: '${episodeId}', hasShareImage=${!!shareImageFromStorage(kvMeta)}.`);
         console.log(logCollector.toEndpointLog());
-        return c.json(pageDetailsFromKv(podcastName, kvMeta));
+        return c.json(pageDetailsFromKv(podcastName, kvMeta, requestUrl));
     }
 
     if (kvExists) {
         logCollector.addMessage(`KV key '${key}' exists but metadata incomplete; leaving unchanged and not recreating.`);
         if (kvMeta) {
             console.log(logCollector.toEndpointLog());
-            return c.json(pageDetailsFromKv(podcastName, kvMeta));
+            return c.json(pageDetailsFromKv(podcastName, kvMeta, requestUrl));
         }
         console.error(logCollector.toEndpointLog());
         return c.text(logCollector.message!, 400);
@@ -104,7 +113,7 @@ export async function getPageDetails(c: ActionContext): Promise<Response> {
             await c.env.shortner.put(key, `${encodedPodcastName}/${episodeId}`, { metadata: shortnerRecord });
             logCollector.addMessage(`Stored kv item with key '${key}'`);
             console.log(logCollector.toEndpointLog());
-            return Response.json(pageDetailsFromKv(podcastName, shortnerRecord));
+            return Response.json(pageDetailsFromKv(podcastName, shortnerRecord, requestUrl));
         }
         logCollector.addMessage(`No item for episode-uuid '${episodeId}' and podcast-name '${podcastName}'`);
         console.error(logCollector.toEndpointLog());

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import {
 	UpdatePodcastPutRoute,
 	UpdateSubjectRoute
 } from './openapiRoutes';
+import { getOgShareImage } from './ogShareImage';
 
 const app = new Hono<{ Bindings: Env }>();
 const OPENAPI_AUTH_COOKIE = 'openapi_access_token';
@@ -329,6 +330,9 @@ openapi.delete('/bookmark/:episodeId', DeleteBookmarkRoute);
 openapi.get('/bookmarks', GetBookmarksRoute);
 openapi.get('/public/episode/:id', PublicGetEpisodeRoute);
 openapi.get('/languages', GetLanguagesRoute);
+
+// Branded OG image (CF Images overlay). Public — crawlers fetch directly.
+app.get('/og-image', getOgShareImage);
 
 export default {
 	fetch: app.fetch,

--- a/src/ipage-details.ts
+++ b/src/ipage-details.ts
@@ -1,6 +1,12 @@
+import { EpisodeShareImageAspect } from "./episodeShareImage";
+
 export interface IPageDetails {
     title?: string,
     description?: string,
     releaseDate?: string,
-    duration?: string
+    duration?: string,
+    /** Absolute HTTPS URL for og:image / twitter:image (expanded from search-index encoding). */
+    image?: string,
+    /** YouTube / BBC iPlayer / Internet Archive → wide; Spotify/Apple/BBC Sounds → square. */
+    imageAspect?: EpisodeShareImageAspect
 }

--- a/src/ipage-details.ts
+++ b/src/ipage-details.ts
@@ -5,7 +5,7 @@ export interface IPageDetails {
     description?: string,
     releaseDate?: string,
     duration?: string,
-    /** Absolute HTTPS URL for og:image / twitter:image (expanded from search-index encoding). */
+    /** Absolute HTTPS URL for og:image / twitter:image — Api `/og-image` (logo overlay) when share art exists. */
     image?: string,
     /** YouTube / BBC iPlayer / Internet Archive → wide; Spotify/Apple/BBC Sounds → square. */
     imageAspect?: EpisodeShareImageAspect

--- a/src/ogShareImage.ts
+++ b/src/ogShareImage.ts
@@ -1,0 +1,94 @@
+import { Context } from "hono";
+import { Env } from "./Env";
+import {
+	DEFAULT_OG_LOGO_URL,
+	isAllowedShareImageSourceHost,
+	parseOgImageAspect
+} from "./episodeShareImage";
+
+type ImageDrawOptions = {
+	url: string;
+	bottom?: number;
+	right?: number;
+	width?: number;
+	height?: number;
+	fit?: string;
+	opacity?: number;
+};
+
+/**
+ * Serves episode art with Cult Podcasts logo overlay via Cloudflare Images
+ * transformations (Free: 5k unique transforms/month). On failure (incl. 9422),
+ * redirects to the original source URL so OG crawlers still get an image.
+ *
+ * GET /og-image?u=<absolute-source-url>&a=wide|square
+ */
+export async function getOgShareImage(c: Context<{ Bindings: Env }>): Promise<Response> {
+	const sourceParam = c.req.query("u");
+	if (!sourceParam) {
+		return c.text("Missing u (source image URL)", 400);
+	}
+
+	let sourceUrl: URL;
+	try {
+		sourceUrl = new URL(sourceParam);
+	} catch {
+		return c.text("Invalid source image URL", 400);
+	}
+
+	if (sourceUrl.protocol !== "https:") {
+		return c.text("Source image must be https", 400);
+	}
+
+	if (!isAllowedShareImageSourceHost(sourceUrl.hostname)) {
+		return c.text("Source image host is not allowed", 400);
+	}
+
+	const aspect = parseOgImageAspect(c.req.query("a"));
+	const width = aspect === "wide" ? 1200 : 800;
+	const logoWidth = aspect === "wide" ? 120 : 96;
+
+	const draw: ImageDrawOptions[] = [
+		{
+			url: DEFAULT_OG_LOGO_URL,
+			bottom: 16,
+			right: 16,
+			width: logoWidth,
+			height: logoWidth,
+			fit: "contain",
+			opacity: 0.92
+		}
+	];
+
+	const imageOptions: Record<string, unknown> = {
+		width,
+		fit: "scale-down",
+		format: "jpeg",
+		quality: 85,
+		draw
+	};
+
+	try {
+		const response = await fetch(sourceUrl.toString(), {
+			cf: {
+				image: imageOptions,
+				cacheEverything: true,
+				cacheTtl: 86400
+			}
+		} as RequestInit);
+
+		if (response.ok || response.redirected) {
+			const headers = new Headers(response.headers);
+			headers.set("Cache-Control", "public, max-age=86400");
+			headers.set("Content-Type", response.headers.get("Content-Type") ?? "image/jpeg");
+			return new Response(response.body, {
+				status: response.status,
+				headers
+			});
+		}
+	} catch {
+		// Fall through to redirect — local/dev and Free-plan overruns (9422) included.
+	}
+
+	return Response.redirect(sourceUrl.toString(), 307);
+}

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -562,7 +562,11 @@ export const pageDetailsResponseSchema = z.object({
 	title: z.string().optional(),
 	description: z.string().optional(),
 	releaseDate: z.string().optional(),
-	duration: z.string().optional()
+	duration: z.string().optional(),
+	/** Absolute HTTPS episode art for social previews. */
+	image: z.string().url().optional(),
+	/** wide (YouTube / BBC iPlayer / Internet Archive) → summary_large_image; square (Spotify/Apple/BBC Sounds) → summary. */
+	imageAspect: z.enum(["wide", "square"]).optional()
 });
 
 /**

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -563,7 +563,7 @@ export const pageDetailsResponseSchema = z.object({
 	description: z.string().optional(),
 	releaseDate: z.string().optional(),
 	duration: z.string().optional(),
-	/** Absolute HTTPS episode art for social previews. */
+	/** Api `/og-image` URL (CF logo overlay) when share art exists; crawlers may fall back to source. */
 	image: z.string().url().optional(),
 	/** wide (YouTube / BBC iPlayer / Internet Archive) → summary_large_image; square (Spotify/Apple/BBC Sounds) → summary. */
 	imageAspect: z.enum(["wide", "square"]).optional()

--- a/tests/episodeShareImage.spec.ts
+++ b/tests/episodeShareImage.spec.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+	expandSearchImage,
+	resolveEpisodeShareImage,
+	shareImageFromStorage,
+	toShareImageStorage
+} from "../src/episodeShareImage";
+
+describe("expandSearchImage (search-index encoding)", () => {
+	it("expands Spotify / Apple / YouTube tokens", () => {
+		expect(expandSearchImage("sab6765ferngully00cover", undefined))
+			.toBe("https://i.scdn.co/image/ab6765ferngully00cover");
+		expect(expandSearchImage("a3Music/draymoor/600x600bb.jpg", undefined))
+			.toBe("https://is3-ssl.mzstatic.com/image/thumb/Music/draymoor/600x600bb.jpg");
+		expect(expandSearchImage("yx", "griffinsong42"))
+			.toBe("https://i.ytimg.com/vi/griffinsong42/maxresdefault.jpg");
+	});
+
+	it("passes through absolute URLs unchanged", () => {
+		expect(expandSearchImage("https://feeds.example/art.jpg", undefined))
+			.toBe("https://feeds.example/art.jpg");
+	});
+});
+
+describe("resolveEpisodeShareImage", () => {
+	it("expands Spotify cover tokens to absolute square art", () => {
+		const share = resolveEpisodeShareImage({ image: "sab6765ferngully00cover" });
+		expect(share).toEqual({
+			image: "https://i.scdn.co/image/ab6765ferngully00cover",
+			imageAspect: "square"
+		});
+	});
+
+	it("expands Apple cover tokens to absolute square art", () => {
+		const share = resolveEpisodeShareImage({ image: "a3Music/draymoor/600x600bb.jpg" });
+		expect(share).toEqual({
+			image: "https://is3-ssl.mzstatic.com/image/thumb/Music/draymoor/600x600bb.jpg",
+			imageAspect: "square"
+		});
+	});
+
+	it("prefers YouTube hqdefault when youtubeId is set (wide card)", () => {
+		const share = resolveEpisodeShareImage({
+			image: "sab6765cover",
+			youtubeId: "griffinsong42"
+		});
+		expect(share).toEqual({
+			image: "https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg",
+			imageAspect: "wide"
+		});
+	});
+
+	it("expands compacted YouTube quality tokens with youtubeId", () => {
+		const share = resolveEpisodeShareImage({ image: "yh", youtubeId: "griffinsong42" });
+		expect(share).toEqual({
+			image: "https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg",
+			imageAspect: "wide"
+		});
+	});
+
+	it("passes through absolute YouTube URLs as wide", () => {
+		const share = resolveEpisodeShareImage({
+			image: "https://i.ytimg.com/vi/abc/hqdefault.jpg"
+		});
+		expect(share?.imageAspect).toBe("wide");
+		expect(share?.image).toContain("i.ytimg.com");
+	});
+
+	it("returns undefined when nothing is resolvable", () => {
+		expect(resolveEpisodeShareImage({})).toBeUndefined();
+		expect(resolveEpisodeShareImage({ image: "yx" })).toBeUndefined();
+	});
+
+	it("treats BBC iPlayer episodes as wide even with square cover art", () => {
+		const share = resolveEpisodeShareImage({
+			image: "sab6765cover",
+			bbc: "https://www.bbc.co.uk/iplayer/episode/p0example"
+		});
+		expect(share).toEqual({
+			image: "https://i.scdn.co/image/ab6765cover",
+			imageAspect: "wide"
+		});
+	});
+
+	it("treats BBC Sounds episodes as square", () => {
+		const share = resolveEpisodeShareImage({
+			image: "sab6765cover",
+			bbc: "https://www.bbc.co.uk/sounds/play/p0example"
+		});
+		expect(share).toEqual({
+			image: "https://i.scdn.co/image/ab6765cover",
+			imageAspect: "square"
+		});
+	});
+
+	it("treats Internet Archive episodes as wide even with square cover art", () => {
+		const share = resolveEpisodeShareImage({
+			image: "a3Music/draymoor/600x600bb.jpg",
+			internetArchive: "https://archive.org/details/example"
+		});
+		expect(share).toEqual({
+			image: "https://is3-ssl.mzstatic.com/image/thumb/Music/draymoor/600x600bb.jpg",
+			imageAspect: "wide"
+		});
+	});
+});
+
+describe("toShareImageStorage / shareImageFromStorage", () => {
+	it("stores search-index tokens and expands them back for page-details", () => {
+		const stored = toShareImageStorage({
+			image: "yx",
+			youtubeId: "griffinsong42"
+		});
+		expect(stored).toEqual({
+			image: "yx",
+			youtubeId: "griffinsong42",
+			imageAspect: "wide"
+		});
+		expect(shareImageFromStorage(stored!)).toEqual({
+			image: "https://i.ytimg.com/vi/griffinsong42/maxresdefault.jpg",
+			imageAspect: "wide"
+		});
+	});
+
+	it("stores Spotify tokens as-is for square episodes", () => {
+		const stored = toShareImageStorage({ image: "sab6765cover" });
+		expect(stored?.image).toBe("sab6765cover");
+		expect(shareImageFromStorage(stored!)?.image)
+			.toBe("https://i.scdn.co/image/ab6765cover");
+	});
+
+	it("stores absolute YouTube URL when index image is Spotify but youtubeId forces a frame", () => {
+		// Display prefers YT; search image stays Spotify — storage keeps the search token,
+		// expand path uses youtubeId → hqdefault for the absolute share URL.
+		const stored = toShareImageStorage({
+			image: "sab6765cover",
+			youtubeId: "griffinsong42"
+		});
+		expect(stored).toEqual({
+			image: "sab6765cover",
+			youtubeId: "griffinsong42",
+			imageAspect: "wide"
+		});
+		expect(shareImageFromStorage(stored!)?.image)
+			.toBe("https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg");
+	});
+});

--- a/tests/episodeShareImage.spec.ts
+++ b/tests/episodeShareImage.spec.ts
@@ -3,7 +3,9 @@ import {
 	expandSearchImage,
 	resolveEpisodeShareImage,
 	shareImageFromStorage,
-	toShareImageStorage
+	toShareImageStorage,
+	buildBrandedOgImageUrl,
+	isAllowedShareImageSourceHost
 } from "../src/episodeShareImage";
 
 describe("expandSearchImage (search-index encoding)", () => {
@@ -143,5 +145,25 @@ describe("toShareImageStorage / shareImageFromStorage", () => {
 		});
 		expect(shareImageFromStorage(stored!)?.image)
 			.toBe("https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg");
+	});
+});
+
+describe("buildBrandedOgImageUrl / allowlist", () => {
+	it("builds Api /og-image URL with source and aspect query params", () => {
+		const branded = buildBrandedOgImageUrl(
+			"https://api.cultpodcasts.com/pagedetails/Show/abc",
+			"https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg",
+			"wide"
+		);
+		expect(branded).toBe(
+			"https://api.cultpodcasts.com/og-image?u=https%3A%2F%2Fi.ytimg.com%2Fvi%2Fgriffinsong42%2Fhqdefault.jpg&a=wide"
+		);
+	});
+
+	it("allows known episode-art hosts and rejects others", () => {
+		expect(isAllowedShareImageSourceHost("i.ytimg.com")).toBe(true);
+		expect(isAllowedShareImageSourceHost("i.scdn.co")).toBe(true);
+		expect(isAllowedShareImageSourceHost("is3-ssl.mzstatic.com")).toBe(true);
+		expect(isAllowedShareImageSourceHost("evil.example")).toBe(false);
 	});
 });

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -264,8 +264,10 @@ describe("openapi Zod schemas", () => {
 			title: "Ep | Show",
 			description: "Show",
 			releaseDate: "01/07/2026",
-			duration: "01:00:00"
-		}).title).toContain("Show");
+			duration: "01:00:00",
+			image: "https://i.scdn.co/image/ab6765cover",
+			imageAspect: "square"
+		}).imageAspect).toBe("square");
 		expect(searchResponseSchema.parse({
 			"@odata.count": 1,
 			value: [{


### PR DESCRIPTION
## Summary
- `/pagedetails` leaves existing shortener keys unchanged.
- On KV miss, creates a shortener record with search-index share-image metadata when available so OG and social posting can use episode artwork.
- Extends ShortnerRecord / OpenAPI / page-details types for `image`, `youtubeId`, and `imageAspect`.

## Test plan
- [ ] Existing shortener key → unchanged metadata (no rewrite)
- [ ] Missing key + search hit with art → KV created with image fields; page-details returns them
- [ ] Missing key + no art → create/return without image (site icon path)
- [ ] `npm test` (episodeShareImage + openapi schemas)
