### PR TITLE
feat(api): serve search-suggestions corpus from R2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
 	GetSubjectsRoute,
 	HomepageRoute,
 	HomepageSsrRoute,
+	SearchSuggestionsRoute,
 	IndexPodcastByNameRoute,
 	PublicGetEpisodeRoute,
 	PublishHomepageRoute,
@@ -276,6 +277,7 @@ const openapi = fromHono(app, {
 
 openapi.get('/homepage', HomepageRoute);
 openapi.get('/homepage-ssr', HomepageSsrRoute);
+openapi.get('/search-suggestions', SearchSuggestionsRoute);
 openapi.get('/subjects', GetSubjectsRoute);
 openapi.get('/people', GetPeopleRoute);
 openapi.get('/person/:name', GetPersonByNameRoute);

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -22,6 +22,7 @@ import { getPeople } from "./getPeople";
 import { getSubjects } from "./getSubjects";
 import { homepage } from "./homepage";
 import { homepageSsr } from "./homepageSsr";
+import { searchSuggestions } from "./searchSuggestions";
 import { indexPodcastByName } from "./indexPodcastByName";
 import {
 	bookmarksListResponseSchema,
@@ -45,6 +46,7 @@ import {
 	flairsResponseSchema,
 	homepageResponseSchema,
 	preProcessedHomepageResponseSchema,
+	searchSuggestionsResponseSchema,
 	indexPodcastResponseSchema,
 	indexerStateDtoSchema,
 	jsonBody,
@@ -176,6 +178,23 @@ export const HomepageSsrRoute = createOpenApiRoute(homepageSsr, {
                 ...contentJson(preProcessedHomepageResponseSchema)
             },
             404: { description: "Pre-processed homepage object missing from R2" }
+        }
+    }
+});
+
+export const SearchSuggestionsRoute = createOpenApiRoute(searchSuggestions, {
+    schema: {
+        tags: ["Public"],
+        summary: "Get search typeahead match index",
+        description:
+            "Returns R2 key `search-suggestions` (ContentOptions.SearchSuggestionsKey): " +
+            "flat match index of subject names/aliases and podcast names for Flix typeahead.",
+        responses: {
+            200: {
+                description: "Search suggestions corpus",
+                ...contentJson(searchSuggestionsResponseSchema)
+            },
+            404: { description: "Search-suggestions object missing from R2" }
         }
     }
 });

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -624,6 +624,19 @@ export const homepageResponseSchema = z.object({
 	totalDuration: z.string()
 });
 
+export const searchSuggestionEntrySchema = z.object({
+	type: z.enum(["subject", "podcast"]),
+	canonical: z.string(),
+	searchText: z.string(),
+	alias: z.string().optional().nullable()
+});
+
+/** R2 `search-suggestions` — flat typeahead match index. */
+export const searchSuggestionsResponseSchema = z.object({
+	generatedAtUtc: z.string(),
+	entries: z.array(searchSuggestionEntrySchema)
+});
+
 /**
  * R2 `homepage-ssr` (PreProcessedHomepageKey) —
  * RedditPodcastPoster.Models.HomePage.PreProcessedHomePageModel (JSON, not HTML).

--- a/src/searchSuggestions.ts
+++ b/src/searchSuggestions.ts
@@ -1,0 +1,50 @@
+import { AddResponseHeaders } from "./AddResponseHeaders";
+import { ActionContext } from "./ActionContext";
+import { LogCollector } from "./LogCollector";
+
+export async function searchSuggestions(c: ActionContext): Promise<Response> {
+	const logCollector = new LogCollector();
+	logCollector.collectRequest(c);
+	const cache = caches.default;
+	const cacheKey = new Request(c.req.url, { method: "GET" });
+	logCollector.add({ message: `cacheKey: ${cacheKey.url}` });
+	const cached = await cache.match(cacheKey);
+	if (cached) {
+		logCollector.addMessage("Served search-suggestions from cache.");
+		console.log(logCollector.toEndpointLog());
+		const hitHeaders = new Headers(cached.headers);
+		hitHeaders.set("X-Search-Suggestions-Cache", "HIT");
+		return new Response(cached.body, {
+			status: cached.status,
+			headers: hitHeaders
+		});
+	}
+
+	let object: R2ObjectBody | null = null;
+	try {
+		object = await c.env.Content.get("search-suggestions");
+	} catch {
+		logCollector.addMessage(`Failure to retrieve search-suggestions`);
+	}
+	if (object === null) {
+		logCollector.addMessage(logCollector.message ?? "No search-suggestions object found");
+		console.error(logCollector.toEndpointLog());
+		return c.notFound();
+	}
+	AddResponseHeaders(c, {
+		cacheControlMaxAge: 3600,
+		etag: object.etag,
+		methods: ["GET", "OPTIONS"]
+	});
+	logCollector.addMessage(`Successfully obtained search-suggestions data.`);
+	console.log(logCollector.toEndpointLog());
+
+	const response = new Response(object.body, {
+		status: 200,
+		headers: new Headers(c.res.headers)
+	});
+	response.headers.set("X-Search-Suggestions-Cache", "MISS");
+
+	await cache.put(cacheKey, response.clone());
+	return response;
+}


### PR DESCRIPTION
## Summary
- Add public `GET /search-suggestions` reading R2 key `search-suggestions`
- Homepage-style Cloudflare edge cache with `max-age=3600`
- OpenAPI schema for the flat typeahead corpus

## Test plan
- [x] `vitest` suite green
- [ ] Deploy worker after RPP seed (already published to R2)
- [ ] `curl`/browser `GET /search-suggestions` returns JSON with `entries`


Made with [Cursor](https://cursor.com)