### PR TITLE
feat(openapi): Discovery containsSyntheticMedia and guests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts-api",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@cfworker/jwt": "^4.0.6",
         "@prisma/adapter-d1": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -119,7 +119,9 @@ const discoveryCurationItemSchema = z.object({
 	enrichedUrlFromSpotify: z.boolean(),
 	matchingPodcasts: z.array(discoveryMatchingPodcastSchema).optional().nullable(),
 	acceptProbability: z.number().optional().nullable(),
-	autoHidden: z.boolean()
+	autoHidden: z.boolean(),
+	containsSyntheticMedia: z.boolean().optional().nullable(),
+	guests: z.array(z.string()).optional().nullable()
 });
 
 export const discoveryCurationResponseSchema = z.object({


### PR DESCRIPTION
## Summary
- Add `containsSyntheticMedia` and `guests` to `discoveryCurationItemSchema` so the Cloudflare worker OpenAPI matches the Discovery API

## Test plan
- [ ] `npm test` / `npm run lint` pass
- [ ] OpenAPI / Chanfana docs show the new optional fields on discovery-curation items