### PR TITLE
fix(openapi): derive Swagger API version from package.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ import {
 	UpdatePodcastPutRoute,
 	UpdateSubjectRoute
 } from './openapiRoutes';
+import packageJson from '../package.json';
 
 const app = new Hono<{ Bindings: Env }>();
 const OPENAPI_AUTH_COOKIE = 'openapi_access_token';
@@ -270,7 +271,7 @@ const openapi = fromHono(app, {
 	schema: {
 		info: {
 			title: 'Cult Podcasts API',
-			version: '1.0.3'
+			version: packageJson.version
 		}
 	}
 });

--- a/tests/openapi-version.spec.ts
+++ b/tests/openapi-version.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("OpenAPI info version", () => {
+	it("uses package.json version instead of a hardcoded string", () => {
+		const index = readFileSync(resolve(process.cwd(), "src/index.ts"), "utf8");
+		const packageJson = JSON.parse(
+			readFileSync(resolve(process.cwd(), "package.json"), "utf8")
+		) as { version: string };
+
+		expect(index).toContain("import packageJson from '../package.json'");
+		expect(index).toContain("version: packageJson.version");
+		expect(index).not.toMatch(/version:\s*'1\.\d+\.\d+'/);
+		expect(packageJson.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+});


### PR DESCRIPTION
## Summary
- Use `package.json` `version` for Chanfana/OpenAPI `info.version` instead of a hardcoded `1.0.3`
- After deploy, `/docs` will show **1.0.6** (current package version, including Discovery schema fields from #128)

## Test plan
- [ ] `npm run lint` / `npm test -- tests/openapi-version.spec.ts` pass
- [ ] Deploy worker; confirm https://api.cultpodcasts.com/docs badge matches `package.json`