### PR TITLE
feat(api): relative day slots in homepage rail order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts-api",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@cfworker/jwt": "^4.0.6",
         "@prisma/adapter-d1": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/HeroCurationDurableObject.ts
+++ b/src/HeroCurationDurableObject.ts
@@ -2,13 +2,13 @@ import { DurableObject } from "cloudflare:workers";
 import { Env } from "./Env";
 import {
 	dedupeAndCap,
+	dedupeAndCapRails,
 	emptyHeroState,
 	HERO_KV_KEY,
 	HeroCurationReplaceInput,
 	HeroCurationReplaceResult,
 	HeroCurationState,
 	MAX_EPISODE_IDS,
-	MAX_RAIL_SUBJECTS,
 	mergeAppendEpisodes,
 	mergePruneToAllowed,
 	storedList
@@ -16,6 +16,7 @@ import {
 
 export {
 	dedupeAndCap,
+	dedupeAndCapRails,
 	HERO_KV_KEY,
 	MAX_EPISODE_IDS,
 	MAX_RAIL_SUBJECTS,
@@ -51,10 +52,7 @@ export class HeroCurationDurableObject extends DurableObject<Env> {
 			? dedupeAndCap(input.episodeIds, MAX_EPISODE_IDS)
 			: current.episodeIds;
 		const railSubjects = input.railSubjects
-			? dedupeAndCap(
-				input.railSubjects.map((subject) => subject.trim()).filter((subject) => subject.length > 0),
-				MAX_RAIL_SUBJECTS
-			)
+			? dedupeAndCapRails(input.railSubjects)
 			: current.railSubjects;
 
 		const state: HeroCurationState = {
@@ -84,10 +82,16 @@ export class HeroCurationDurableObject extends DurableObject<Env> {
 
 	async pruneToAllowedIds(
 		allowedEpisodeIds: string[],
-		allowedRailSubjects?: string[]
+		allowedRailSubjects?: string[],
+		dayCount?: number
 	): Promise<{ state: HeroCurationState; pruned: boolean }> {
 		const current = await this.loadOrMigrate();
-		const result = mergePruneToAllowed(current, allowedEpisodeIds, allowedRailSubjects);
+		const result = mergePruneToAllowed(
+			current,
+			allowedEpisodeIds,
+			allowedRailSubjects,
+			dayCount
+		);
 		if (!result.pruned) {
 			return result;
 		}
@@ -110,7 +114,7 @@ export class HeroCurationDurableObject extends DurableObject<Env> {
 			if (fromKv) {
 				const migrated: HeroCurationState = {
 					episodeIds: dedupeAndCap(storedList(fromKv.episodeIds), MAX_EPISODE_IDS),
-					railSubjects: dedupeAndCap(storedList(fromKv.railSubjects), MAX_RAIL_SUBJECTS),
+					railSubjects: dedupeAndCapRails(storedList(fromKv.railSubjects)),
 					updatedAt: fromKv.updatedAt ?? new Date().toISOString()
 				};
 				await this.ctx.storage.put(STORAGE_KEY, migrated);

--- a/src/heroCurationLogic.ts
+++ b/src/heroCurationLogic.ts
@@ -1,6 +1,10 @@
 export const HERO_KV_KEY = "hero-episode-ids";
 export const MAX_EPISODE_IDS = 50;
 export const MAX_RAIL_SUBJECTS = 12;
+/** Relative day slots day:0 … day:N (homepage week is ~7 days; allow a little headroom). */
+export const MAX_DAY_RAIL_OFFSET = 13;
+
+const DAY_RAIL_RE = /^day:(\d+)$/;
 
 export type HeroCurationState = {
 	episodeIds: string[];
@@ -38,6 +42,52 @@ export function dedupeAndCap(values: string[], max: number): string[] {
 	return result;
 }
 
+export function parseDayRailOffset(entry: string): number | null {
+	const match = DAY_RAIL_RE.exec(entry);
+	if (!match) {
+		return null;
+	}
+	return Number.parseInt(match[1], 10);
+}
+
+export function isDayRailEntry(entry: string): boolean {
+	return parseDayRailOffset(entry) !== null;
+}
+
+/**
+ * Dedupe a mixed rail order (relative day slots + subject names).
+ * Subjects are capped at {@link MAX_RAIL_SUBJECTS}; day offsets must be ≤ {@link MAX_DAY_RAIL_OFFSET}.
+ */
+export function dedupeAndCapRails(values: string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	let subjectCount = 0;
+
+	for (const raw of values) {
+		const value = raw.trim();
+		if (value.length === 0 || seen.has(value)) {
+			continue;
+		}
+		const offset = parseDayRailOffset(value);
+		if (offset !== null) {
+			if (offset > MAX_DAY_RAIL_OFFSET) {
+				continue;
+			}
+			seen.add(value);
+			result.push(`day:${offset}`);
+			continue;
+		}
+		if (subjectCount >= MAX_RAIL_SUBJECTS) {
+			continue;
+		}
+		seen.add(value);
+		result.push(value);
+		subjectCount += 1;
+	}
+
+	return result;
+}
+
 export function emptyHeroState(): HeroCurationState {
 	return {
 		episodeIds: [],
@@ -69,7 +119,8 @@ export function mergeAppendEpisodes(
 export function mergePruneToAllowed(
 	current: HeroCurationState,
 	allowedEpisodeIds: string[],
-	allowedRailSubjects?: string[]
+	allowedRailSubjects?: string[],
+	dayCount?: number
 ): { state: HeroCurationState; pruned: boolean } {
 	const episodeAllow = new Set(allowedEpisodeIds);
 	const nextEpisodes = current.episodeIds.filter((id) => episodeAllow.has(id));
@@ -77,7 +128,14 @@ export function mergePruneToAllowed(
 	let nextRails = current.railSubjects;
 	if (allowedRailSubjects) {
 		const railAllow = new Set(allowedRailSubjects);
-		nextRails = current.railSubjects.filter((subject) => railAllow.has(subject));
+		const maxDay = dayCount ?? MAX_DAY_RAIL_OFFSET + 1;
+		nextRails = current.railSubjects.filter((entry) => {
+			const offset = parseDayRailOffset(entry);
+			if (offset !== null) {
+				return offset < maxDay;
+			}
+			return railAllow.has(entry);
+		});
 	}
 
 	const pruned =
@@ -99,4 +157,3 @@ export function mergePruneToAllowed(
 		pruned: true
 	};
 }
-

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -64,9 +64,11 @@ export const discoveryScheduleResponseSchema = z.object({
 });
 
 /**
- * PUT /hero-curation — ordered hero episode UUIDs and/or ordered homepage rail
- * subjects. Both members are optional so a caller can update one without
- * clobbering the other; the handler merges, dedupes, and caps each list.
+ * PUT /hero-curation — ordered hero episode UUIDs and/or ordered homepage rails.
+ * `railSubjects` is a mixed list of pinned subject names and relative day slots
+ * (`day:0` = newest / n, `day:1` = n−1, …). Both members are optional so a caller
+ * can update one without clobbering the other; the handler merges, dedupes, and
+ * caps each list.
  */
 export const heroCurationUpdateRequestSchema = z.object({
 	episodeIds: z.array(z.string().uuid()).optional(),
@@ -79,7 +81,7 @@ export const heroCurationAppendRequestSchema = z.object({
 	episodeIds: z.array(z.string().uuid()).min(1)
 });
 
-/** GET/PUT /hero-curation — curated hero episode IDs and pinned rail subjects. */
+/** GET/PUT /hero-curation — curated hero episode IDs and pinned homepage rails. */
 export const heroCurationResponseSchema = z.object({
 	episodeIds: z.array(z.string().uuid()),
 	railSubjects: z.array(z.string()),

--- a/src/pruneHeroCurationScheduled.ts
+++ b/src/pruneHeroCurationScheduled.ts
@@ -2,7 +2,7 @@ import { Env } from "./Env";
 import { heroCurationStub } from "./HeroCurationDurableObject";
 
 type HomepagePayload = {
-	recentEpisodes?: Array<{ id?: string; subjects?: string[] }>;
+	recentEpisodes?: Array<{ id?: string; subjects?: string[]; release?: string }>;
 };
 
 /**
@@ -35,7 +35,14 @@ export async function pruneHeroCurationScheduled(env: Env): Promise<void> {
 		.filter((id): id is string => typeof id === "string" && id.length > 0);
 
 	const allowedRailSubjects = new Set<string>();
+	const releaseDays = new Set<string>();
 	for (const ep of recent) {
+		if (typeof ep.release === "string") {
+			const day = ep.release.slice(0, 10);
+			if (/^\d{4}-\d{2}-\d{2}$/.test(day)) {
+				releaseDays.add(day);
+			}
+		}
 		if (!Array.isArray(ep.subjects)) {
 			continue;
 		}
@@ -49,7 +56,8 @@ export async function pruneHeroCurationScheduled(env: Env): Promise<void> {
 	try {
 		const { state, pruned } = await heroCurationStub(env).pruneToAllowedIds(
 			allowedEpisodeIds,
-			[...allowedRailSubjects]
+			[...allowedRailSubjects],
+			releaseDays.size
 		);
 		if (pruned) {
 			console.log(
@@ -62,4 +70,3 @@ export async function pruneHeroCurationScheduled(env: Env): Promise<void> {
 		console.error("hero-prune: Durable Object prune failed", error);
 	}
 }
-

--- a/tests/hero-curation.spec.ts
+++ b/tests/hero-curation.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { dedupeAndCap, MAX_EPISODE_IDS, MAX_RAIL_SUBJECTS } from "../src/heroCurationLogic";
+import { dedupeAndCap, dedupeAndCapRails, MAX_EPISODE_IDS, MAX_RAIL_SUBJECTS, mergePruneToAllowed } from "../src/heroCurationLogic";
 
 /**
  * Source-contract checks for /hero-curation (GET public, PUT/POST curate + DO).
@@ -11,6 +11,7 @@ describe("hero-curation contract", () => {
 	const routes = readFileSync(resolve(process.cwd(), "src/openapiRoutes.ts"), "utf8");
 	const index = readFileSync(resolve(process.cwd(), "src/index.ts"), "utf8");
 	const wrangler = readFileSync(resolve(process.cwd(), "wrangler.jsonc"), "utf8");
+	const logic = readFileSync(resolve(process.cwd(), "src/heroCurationLogic.ts"), "utf8");
 
 	it("registers GET, PUT, and POST append routes", () => {
 		expect(index).toContain("openapi.get('/hero-curation', GetHeroCurationRoute)");
@@ -79,6 +80,37 @@ describe("hero-curation contract", () => {
 		expect(MAX_RAIL_SUBJECTS).toBe(12);
 		expect(dedupeAndCap(["a", "a", "b"], 50)).toEqual(["a", "b"]);
 		expect(dedupeAndCap(Array.from({ length: 60 }, (_, i) => `id-${i}`), 50)).toHaveLength(50);
+	});
+
+	it("dedupes mixed day slots and subject rails without capping days as subjects", () => {
+		expect(logic).toContain("dedupeAndCapRails");
+		expect(dedupeAndCapRails([
+			"day:0",
+			"Scientology",
+			"day:0",
+			"NXIVM",
+			"day:1",
+			"Scientology"
+		])).toEqual(["day:0", "Scientology", "NXIVM", "day:1"]);
+		const manySubjects = Array.from({ length: 20 }, (_, i) => `Subject ${i}`);
+		const capped = dedupeAndCapRails(["day:0", ...manySubjects, "day:1"]);
+		expect(capped.filter((entry) => entry.startsWith("day:"))).toEqual(["day:0", "day:1"]);
+		expect(capped.filter((entry) => !entry.startsWith("day:")).length).toBe(12);
+	});
+
+	it("prunes stale subjects but keeps in-range day slots", () => {
+		const { state, pruned } = mergePruneToAllowed(
+			{
+				episodeIds: ["11111111-1111-1111-1111-111111111111"],
+				railSubjects: ["day:0", "Gone", "Scientology", "day:2", "day:1"],
+				updatedAt: "2026-01-01T00:00:00.000Z"
+			},
+			["11111111-1111-1111-1111-111111111111"],
+			["Scientology"],
+			2
+		);
+		expect(pruned).toBe(true);
+		expect(state.railSubjects).toEqual(["day:0", "Scientology", "day:1"]);
 	});
 
 	it("supports expectedUpdatedAt conflict responses", () => {


### PR DESCRIPTION
## Summary
- Extend `railSubjects` to accept relative day slots (`day:0` = n, `day:1` = n−1, …) mixed with subject pins
- Cap subjects at 12 while preserving day slots; prune drops out-of-range day offsets against the homepage week
- Document the mixed-list contract in OpenAPI schemas

## Test plan
- [ ] `npm test -- --run tests/hero-curation.spec.ts`
- [ ] PUT `/hero-curation` with mixed `["day:1","Scientology","day:0"]` and confirm GET round-trips
- [ ] Confirm subject-only legacy lists still save and prune as before
