### PR TITLE
feat(api): DELETE /hero-curation/episodes for demote

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts-api",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "dependencies": {
         "@cfworker/jwt": "^4.0.6",
         "@prisma/adapter-d1": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/HeroCurationDurableObject.ts
+++ b/src/HeroCurationDurableObject.ts
@@ -10,6 +10,7 @@ import {
 	HeroCurationState,
 	MAX_EPISODE_IDS,
 	mergeAppendEpisodes,
+	mergeRemoveEpisodes,
 	mergePruneToAllowed,
 	storedList
 } from "./heroCurationLogic";
@@ -76,6 +77,22 @@ export class HeroCurationDurableObject extends DurableObject<Env> {
 		await this.ctx.storage.put(STORAGE_KEY, next);
 		console.log(
 			`Hero auto-promote: DO stored append. EpisodeIds: ${episodeIds.join(",")}. Total: ${next.episodeIds.length}. UpdatedAt: ${next.updatedAt}.`
+		);
+		return next;
+	}
+
+	async removeEpisodes(episodeIds: string[]): Promise<HeroCurationState> {
+		const current = await this.loadOrMigrate();
+		const next = mergeRemoveEpisodes(current, episodeIds);
+		if (!next) {
+			console.log(
+				`Hero demote: DO remove no-op (none present). EpisodeIds: ${episodeIds.join(",")}. Total: ${current.episodeIds.length}.`
+			);
+			return current;
+		}
+		await this.ctx.storage.put(STORAGE_KEY, next);
+		console.log(
+			`Hero demote: DO stored remove. EpisodeIds: ${episodeIds.join(",")}. Total: ${next.episodeIds.length}. UpdatedAt: ${next.updatedAt}.`
 		);
 		return next;
 	}

--- a/src/heroCuration.ts
+++ b/src/heroCuration.ts
@@ -34,7 +34,7 @@ export async function getHeroCuration(c: ActionContext): Promise<Response> {
 	const logCollector = new LogCollector();
 	logCollector.collectRequest(c);
 	AddResponseHeaders(c, {
-		methods: ["GET", "PUT", "POST", "OPTIONS"],
+		methods: ["GET", "PUT", "POST", "DELETE", "OPTIONS"],
 		cacheControlMaxAge: 60
 	});
 
@@ -57,7 +57,7 @@ export async function getHeroCuration(c: ActionContext): Promise<Response> {
 export async function putHeroCuration(c: Auth0ActionContext): Promise<Response> {
 	const logCollector = new LogCollector();
 	logCollector.collectRequest(c);
-	AddResponseHeaders(c, { methods: ["GET", "PUT", "POST", "OPTIONS"] });
+	AddResponseHeaders(c, { methods: ["GET", "PUT", "POST", "DELETE", "OPTIONS"] });
 
 	const denied = requireCurate(c, logCollector);
 	if (denied) {
@@ -117,7 +117,7 @@ export async function putHeroCuration(c: Auth0ActionContext): Promise<Response> 
 export async function appendHeroCurationEpisodes(c: Auth0ActionContext): Promise<Response> {
 	const logCollector = new LogCollector();
 	logCollector.collectRequest(c);
-	AddResponseHeaders(c, { methods: ["GET", "PUT", "POST", "OPTIONS"] });
+	AddResponseHeaders(c, { methods: ["GET", "PUT", "POST", "DELETE", "OPTIONS"] });
 
 	const denied = requireCurate(c, logCollector);
 	if (denied) {
@@ -152,6 +152,47 @@ export async function appendHeroCurationEpisodes(c: Auth0ActionContext): Promise
 		logCollector.addMessage("Hero auto-promote: unable to append hero curation episodes");
 		console.error(logCollector.toEndpointLog(), error);
 		return c.json({ error: "Failed to append hero episodes" }, 500);
+	}
+}
+
+export async function deleteHeroCurationEpisodes(c: Auth0ActionContext): Promise<Response> {
+	const logCollector = new LogCollector();
+	logCollector.collectRequest(c);
+	AddResponseHeaders(c, { methods: ["GET", "PUT", "POST", "DELETE", "OPTIONS"] });
+
+	const denied = requireCurate(c, logCollector);
+	if (denied) {
+		return denied;
+	}
+
+	let body: unknown;
+	try {
+		body = await c.req.json();
+	} catch {
+		logCollector.addMessage("Invalid JSON body for deleteHeroCurationEpisodes.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Bad request" }, 400);
+	}
+
+	const parsed = heroCurationAppendRequestSchema.safeParse(body);
+	if (!parsed.success || parsed.data.episodeIds.length === 0) {
+		logCollector.addMessage("Invalid hero curation delete body.");
+		console.error(logCollector.toEndpointLog());
+		return c.json({ error: "Bad request" }, 400);
+	}
+
+	try {
+		const requested = parsed.data.episodeIds;
+		const state = await heroCurationStub(c.env).removeEpisodes(requested);
+		logCollector.addMessage(
+			`Hero demote: DO remove (${requested.length} requested, ${state.episodeIds.length} total). EpisodeIds: ${requested.join(",")}.`
+		);
+		console.log(logCollector.toEndpointLog());
+		return c.json(state, 200);
+	} catch (error) {
+		logCollector.addMessage("Hero demote: unable to remove hero curation episodes");
+		console.error(logCollector.toEndpointLog(), error);
+		return c.json({ error: "Failed to remove hero episodes" }, 500);
 	}
 }
 

--- a/src/heroCurationLogic.ts
+++ b/src/heroCurationLogic.ts
@@ -116,6 +116,29 @@ export function mergeAppendEpisodes(
 	};
 }
 
+/**
+ * Remove episode IDs from the hero list. Idempotent — missing IDs are ignored.
+ * Returns null when nothing changes (no CAS required).
+ */
+export function mergeRemoveEpisodes(
+	current: HeroCurationState,
+	episodeIds: string[]
+): HeroCurationState | null {
+	const toRemove = new Set(episodeIds.filter((id) => typeof id === "string" && id.length > 0));
+	if (toRemove.size === 0) {
+		return null;
+	}
+	const nextEpisodes = current.episodeIds.filter((id) => !toRemove.has(id));
+	if (nextEpisodes.length === current.episodeIds.length) {
+		return null;
+	}
+	return {
+		episodeIds: nextEpisodes,
+		railSubjects: current.railSubjects,
+		updatedAt: new Date().toISOString()
+	};
+}
+
 export function mergePruneToAllowed(
 	current: HeroCurationState,
 	allowedEpisodeIds: string[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import {
 	PublishTermRoute,
 	GetDiscoveryScheduleRoute,
 	AppendHeroCurationEpisodesRoute,
+	DeleteHeroCurationEpisodesRoute,
 	GetHeroCurationRoute,
 	PutDiscoveryScheduleRoute,
 	PutHeroCurationRoute,
@@ -324,6 +325,7 @@ openapi.put('/discovery-schedule', PutDiscoveryScheduleRoute);
 openapi.get('/hero-curation', GetHeroCurationRoute);
 openapi.put('/hero-curation', PutHeroCurationRoute);
 openapi.post('/hero-curation/episodes', AppendHeroCurationEpisodesRoute);
+openapi.delete('/hero-curation/episodes', DeleteHeroCurationEpisodesRoute);
 openapi.post('/podcast/name/:name', RenamePodcastRoute);
 openapi.post('/pushsubscription', PushSubscriptionRoute);
 openapi.get('/pagedetails/:podcastName/:episodeId', GetPageDetailsRoute);

--- a/src/openapiRoutes.ts
+++ b/src/openapiRoutes.ts
@@ -34,6 +34,7 @@ import {
 	heroCurationResponseSchema,
 	heroCurationUpdateRequestSchema,
 	heroCurationAppendRequestSchema,
+	heroCurationDeleteEpisodesRequestSchema,
 	discoverySubmitResponseSchema,
 	episodeChangeRequestSchema,
 	episodeDeleteBlockedSchema,
@@ -77,7 +78,7 @@ import { publishPodcastEpisode } from "./publish";
 import { publishHomepage } from "./publishHomepage";
 import { publishTerm } from "./publishTerm";
 import { getDiscoverySchedule, putDiscoverySchedule } from "./discoverySchedule";
-import { appendHeroCurationEpisodes, getHeroCuration, putHeroCuration } from "./heroCuration";
+import { appendHeroCurationEpisodes, deleteHeroCurationEpisodes, getHeroCuration, putHeroCuration } from "./heroCuration";
 import { pushSubscription } from "./pushSubscription";
 import { renamePodcast } from "./renamePodcast";
 import { runSearchIndexer } from "./runSearchIndexer";
@@ -694,6 +695,21 @@ export const AppendHeroCurationEpisodesRoute = createOpenApiRoute(appendHeroCura
         request: { body: jsonBody(heroCurationAppendRequestSchema) },
         responses: {
             200: { description: "Hero curation after append", ...contentJson(heroCurationResponseSchema) },
+            400: { description: "Bad request", ...contentJson(errorSchema) },
+            ...serverErrorResponse,
+            ...authResponses
+        }
+    }
+});
+
+export const DeleteHeroCurationEpisodesRoute = createOpenApiRoute(deleteHeroCurationEpisodes, {
+    auth: true,
+    schema: {
+        tags: ["Curation"],
+        summary: "Remove episode IDs from curated hero list (demote / unstar)",
+        request: { body: jsonBody(heroCurationDeleteEpisodesRequestSchema) },
+        responses: {
+            200: { description: "Hero curation after remove", ...contentJson(heroCurationResponseSchema) },
             400: { description: "Bad request", ...contentJson(errorSchema) },
             ...serverErrorResponse,
             ...authResponses

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -76,10 +76,13 @@ export const heroCurationUpdateRequestSchema = z.object({
 	expectedUpdatedAt: z.string().datetime({ offset: true }).optional().nullable()
 });
 
-/** POST /hero-curation/episodes — append episode IDs (indexer auto-promote). */
+/** POST/DELETE /hero-curation/episodes — append or remove episode IDs (no CAS). */
 export const heroCurationAppendRequestSchema = z.object({
 	episodeIds: z.array(z.string().uuid()).min(1)
 });
+
+/** Alias — same body shape for DELETE demote. */
+export const heroCurationDeleteEpisodesRequestSchema = heroCurationAppendRequestSchema;
 
 /** GET/PUT /hero-curation — curated hero episode IDs and pinned homepage rails. */
 export const heroCurationResponseSchema = z.object({

--- a/tests/hero-curation.spec.ts
+++ b/tests/hero-curation.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { dedupeAndCap, dedupeAndCapRails, MAX_EPISODE_IDS, MAX_RAIL_SUBJECTS, mergePruneToAllowed } from "../src/heroCurationLogic";
+import { dedupeAndCap, dedupeAndCapRails, MAX_EPISODE_IDS, MAX_RAIL_SUBJECTS, mergePruneToAllowed, mergeRemoveEpisodes } from "../src/heroCurationLogic";
 
 /**
- * Source-contract checks for /hero-curation (GET public, PUT/POST curate + DO).
+ * Source-contract checks for /hero-curation (GET public, PUT/POST/DELETE curate + DO).
  */
 describe("hero-curation contract", () => {
 	const src = readFileSync(resolve(process.cwd(), "src/heroCuration.ts"), "utf8");
@@ -13,13 +13,14 @@ describe("hero-curation contract", () => {
 	const wrangler = readFileSync(resolve(process.cwd(), "wrangler.jsonc"), "utf8");
 	const logic = readFileSync(resolve(process.cwd(), "src/heroCurationLogic.ts"), "utf8");
 
-	it("registers GET, PUT, and POST append routes", () => {
+	it("registers GET, PUT, POST append, and DELETE remove routes", () => {
 		expect(index).toContain("openapi.get('/hero-curation', GetHeroCurationRoute)");
 		expect(index).toContain("openapi.put('/hero-curation', PutHeroCurationRoute)");
 		expect(index).toContain("openapi.post('/hero-curation/episodes', AppendHeroCurationEpisodesRoute)");
+		expect(index).toContain("openapi.delete('/hero-curation/episodes', DeleteHeroCurationEpisodesRoute)");
 	});
 
-	it("GET is public; PUT and POST require Auth0 middleware", () => {
+	it("GET is public; PUT, POST, and DELETE require Auth0 middleware", () => {
 		const getBlock = routes.match(
 			/export const GetHeroCurationRoute = createOpenApiRoute\(getHeroCuration, \{[\s\S]*?\n\}\);/
 		)?.[0];
@@ -29,12 +30,17 @@ describe("hero-curation contract", () => {
 		const appendBlock = routes.match(
 			/export const AppendHeroCurationEpisodesRoute = createOpenApiRoute\(appendHeroCurationEpisodes, \{[\s\S]*?\n\}\);/
 		)?.[0];
+		const deleteBlock = routes.match(
+			/export const DeleteHeroCurationEpisodesRoute = createOpenApiRoute\(deleteHeroCurationEpisodes, \{[\s\S]*?\n\}\);/
+		)?.[0];
 		expect(getBlock).toBeDefined();
 		expect(putBlock).toBeDefined();
 		expect(appendBlock).toBeDefined();
+		expect(deleteBlock).toBeDefined();
 		expect(getBlock).not.toContain("auth: true");
 		expect(putBlock).toContain("auth: true");
 		expect(appendBlock).toContain("auth: true");
+		expect(deleteBlock).toContain("auth: true");
 	});
 
 	it("mutations enforce curate permission with 401/403", () => {
@@ -120,6 +126,25 @@ describe("hero-curation contract", () => {
 
 	it("rejects a PUT carrying neither episodeIds nor railSubjects", () => {
 		expect(src).toContain("!parsed.data.episodeIds && !parsed.data.railSubjects");
+	});
+
+	it("mergeRemoveEpisodes drops matching IDs and is a no-op when none match", () => {
+		const current = {
+			episodeIds: ["a", "b", "c"],
+			railSubjects: ["day:0"],
+			updatedAt: "2026-01-01T00:00:00.000Z"
+		};
+		const removed = mergeRemoveEpisodes(current, ["b", "missing"]);
+		expect(removed?.episodeIds).toEqual(["a", "c"]);
+		expect(removed?.railSubjects).toEqual(["day:0"]);
+		expect(mergeRemoveEpisodes(current, ["missing"])).toBeNull();
+		expect(mergeRemoveEpisodes(current, [])).toBeNull();
+	});
+
+	it("DELETE remove handler calls Durable Object removeEpisodes", () => {
+		expect(src).toContain("deleteHeroCurationEpisodes");
+		expect(src).toContain("removeEpisodes");
+		expect(logic).toContain("mergeRemoveEpisodes");
 	});
 });
 


### PR DESCRIPTION
## Summary
- Add `DELETE /hero-curation/episodes` (curate-auth) that removes episode IDs via Durable Object `removeEpisodes` / `mergeRemoveEpisodes` (idempotent, no CAS).
- Bump package version to 1.0.8.
- Extend OpenAPI + contract tests for the remove path.

## Test plan
- [ ] `npm test -- tests/hero-curation.spec.ts` and `npm run lint`
- [ ] DELETE with `{ episodeIds: [...] }` removes matching IDs and returns updated state
- [ ] DELETE of already-absent IDs is a no-op 200 with unchanged list
- [ ] Unauthenticated / non-curate callers get 401/403