### PR TITLE
docs: Workers Builds for api-preview from Git PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ Preview (e.g. `api-preview.<account>.workers.dev`):
 ```bash
 npx wrangler deploy --env preview
 ```
+
+### Workers Builds (Git deploy)
+
+Do **not** rely on a local `wrangler deploy` for shared hosts. Cloudflare Workers Builds deploys from Git:
+
+| Worker | Git Builds | Deploy command | Triggers |
+|--------|------------|----------------|----------|
+| `api` | connected | `npx wrangler deploy` | `main` only |
+| `api-preview` | connected | `npx wrangler deploy --env preview` | `main` + PR branches |
+
+Both Workers use build command `./build.sh` and the same repo (`cultpodcasts/Api`). On **api-preview**, enable **Builds for non-production branches** and set the non-production deploy command to `npx wrangler deploy --env preview` (not the default `versions upload`) so PR pushes update the shared `api-preview` host.
+
+**Caveat:** concurrent open PRs overwrite each other on `api-preview` (latest successful build wins). That matches the single staging API URL the website uses.
+
+Dashboard: [api Builds](https://dash.cloudflare.com/bae3f835f19899c6eee1ec48f2d658cf/workers/services/view/api/production/settings) · [api-preview Builds](https://dash.cloudflare.com/bae3f835f19899c6eee1ec48f2d658cf/workers/services/view/api-preview/production/settings).
+
 ## Hero auto-promote (Azure M2M)
 
 Azure Functions append hero episodes via Auth0 M2M → `POST /hero-curation/episodes`. Committed defaults use **`https://api.cultpodcasts.com`**. Free-plan Bot Fight Mode can challenge M2M against the custom domain; production may temporarily use the Worker **workers.dev** host via Key Vault secret **`Api-Endpoint`** / Azure `api__Endpoint` only — **never commit a personal workers.dev URL**. Long-term: Pro WAF skip for Bearer on `/hero-curation`. Public browsers stay on the custom domain.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts-api",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "dependencies": {
         "@cfworker/jwt": "^4.0.6",
         "@prisma/adapter-d1": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -81,6 +81,8 @@
   ],
   "env": {
     "preview": {
+      // Explicit so Workers Builds name-check matches the api-preview service.
+      "name": "api-preview",
       "observability": {
         "enabled": true
       },


### PR DESCRIPTION
## Summary
- Document dual-worker Workers Builds: `api` (main → production) and `api-preview` (main + PR branches → `wrangler deploy --env preview`).
- Set explicit `name: api-preview` under `env.preview` so Builds name-check matches the dashboard service.
- Note shared-preview overwrite caveat for concurrent PRs.

## Test plan
- [ ] On api-preview Builds: Connect `cultpodcasts/Api`, build `./build.sh`, deploy `npx wrangler deploy --env preview`, enable non-prod branches with the same deploy command
- [ ] Open/merge this PR and confirm an api-preview build runs
- [ ] `/docs` on api-preview shows current `package.json` version (not stale 1.0.3)