### PR TITLE
docs: preview/production Worker secrets parity guardrail

### DIFF
--- a/.cursor/rules/preview-production-secrets-parity.mdc
+++ b/.cursor/rules/preview-production-secrets-parity.mdc
@@ -1,0 +1,63 @@
+---
+description: New preview/staging Worker secrets MUST be named in the PR and mirrored to production at deploy
+alwaysApply: true
+---
+
+# Preview ↔ production secrets parity (HARD GUARDRAIL)
+
+**Incident (Aug 2026):** New Azure proxy endpoint secrets (`secureSupportedLanguagesEndpoint`, `secureTitleCasingRulesEndpoint`) were added for preview / put on the wrong Worker env. Production `api` kept 500ing on authenticated admin GETs until secrets were set on the live top-level Worker.
+
+## When this applies
+
+Any change that introduces or requires a **new** Cloudflare Worker secret / binding value for:
+
+- Preview / staging API (`api-preview`, `--env preview`, `local-secrets.preview.env*`)
+- Production API (top-level Worker `api`, `local-secrets.production.env*`)
+
+Same rule for website / Pages when a PR adds Preview env vars or secrets that production will need.
+
+## Forbidden
+
+| NEVER | Why |
+|-------|-----|
+| Add a preview-only secret and leave production unset | Prod 500s / silent missing config at release |
+| Put secrets only on `api-production` (`--env production`) | Live traffic is top-level **`api`** (`npm run deploy`) |
+| Commit secret **values** | Use gitignored local env files + `wrangler secret put` |
+| Open/merge a PR that needs a new secret without naming it | Deployers cannot find what to set |
+
+## Required on every such PR
+
+1. **Document secret names (not values)** in the PR body under a **`## Config / secrets`** section, e.g.:
+
+   ```markdown
+   ## Config / secrets
+   - [ ] Preview Worker (`api-preview`): `secureExampleEndpoint`
+   - [ ] Production Worker (`api`, top-level — not `--env production`): `secureExampleEndpoint`
+   - [ ] Tracked examples updated: `scripts/local-secrets.preview.env.example` + `scripts/local-secrets.production.env.example`
+   - [ ] Upload scripts list the key: `set-secrets-preview.ps1` + `set-secrets-production.ps1`
+   ```
+
+2. **Keep key-name parity** between preview and production:
+   - Both `*.env.example` files
+   - Both `set-secrets-*.ps1` `$secretNames` / `$mustBeNonEmpty` lists
+   - Run `pwsh ./scripts/assert-secrets-example-parity.ps1` (must be clean)
+
+3. **At deploy / release time** (agent or human):
+   - Open the merged PR(s) and read **`## Config / secrets`**
+   - Set each named key on **preview** (`--env preview`) **and** live **production** top-level `api` (`--env=` / `set-secrets-production.ps1`)
+   - Do **not** treat “preview works” as production-ready until production secrets are confirmed
+
+## Production Worker target (Api)
+
+| Target | How |
+|--------|-----|
+| Live production | Top-level Worker **`api`** — `wrangler secret put <KEY> --env=` or `.\scripts\set-secrets-production.ps1` |
+| Preview | Worker **`api-preview`** — `--env preview` / `.\scripts\set-secrets-preview.ps1` |
+| Wrong | `--env production` → `api-production` (does **not** serve `api.cultpodcasts.com`) |
+
+## Checklist
+
+- [ ] New secret **name** in PR `## Config / secrets` for preview **and** production
+- [ ] Both `.env.example` files and both set-secrets scripts updated
+- [ ] `assert-secrets-example-parity.ps1` clean
+- [ ] Deploy plan includes `wrangler secret put` (or set-secrets script) for **both** environments — values never in git

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- 1–3 bullets: what and why -->
+
+## Config / secrets
+
+<!-- Required when this PR adds or depends on new Cloudflare Worker secrets / endpoint URLs.
+     List **names only** (never values). Tick both environments before merge/release. -->
+
+- [ ] No new Worker secrets / endpoint env keys
+- [ ] **Or** new secret **names** (preview + production):
+  - Preview (`api-preview`): `<!-- e.g. secureExampleEndpoint -->`
+  - Production (top-level Worker `api` — **not** `--env production`): `<!-- same names -->`
+- [ ] Tracked examples updated: `scripts/local-secrets.preview.env.example` + `scripts/local-secrets.production.env.example`
+- [ ] Upload scripts updated: `set-secrets-preview.ps1` + `set-secrets-production.ps1`
+- [ ] `pwsh ./scripts/assert-secrets-example-parity.ps1` clean
+
+At deploy time: read this section and set every named key on **both** Workers before calling the release done.
+
+## Test plan
+
+- [ ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Cult Podcasts API Worker — agent notes
+
+Cloudflare Worker gateway (`api` / `api-preview`) in front of Azure Functions (`api-infra`).
+
+## Preview ↔ production secrets (HARD)
+
+Any new Worker secret for preview/staging **must** also be planned for production.
+
+- Rule: [`.cursor/rules/preview-production-secrets-parity.mdc`](.cursor/rules/preview-production-secrets-parity.mdc)
+- Docs: [`docs/worker-secrets.md`](docs/worker-secrets.md)
+- PR body **must** include `## Config / secrets` with **secret names** (never values)
+- Parity check: `pwsh ./scripts/assert-secrets-example-parity.ps1`
+- Live production secrets go on top-level Worker **`api`** (`set-secrets-production.ps1` / `--env=`). Do **not** use `--env production` (that is `api-production`, not serving `api.cultpodcasts.com`).
+
+## Version
+
+Semver patch (or higher) in `package.json` + `package-lock.json` on every shipping PR.

--- a/docs/worker-secrets.md
+++ b/docs/worker-secrets.md
@@ -2,6 +2,25 @@
 
 Worker secrets (Search API key, Auth0 client id, Azure Function endpoint URLs, etc.) must **never** be committed to git.
 
+## Preview ↔ production parity (required)
+
+New secrets added for preview/staging **must** be mirrored for production. Forgetting this has caused production 500s on release (Aug 2026: supported-languages / title-casing endpoint secrets).
+
+| Requirement | Detail |
+|-------------|--------|
+| Same **key names** | Preview and production `.env.example` files + both `set-secrets-*.ps1` lists |
+| PR documents names | PR body section **`## Config / secrets`** lists every new secret **name** (never values) for preview **and** production |
+| Deploy reads the PR | Before calling a release done, set each named key on both Workers |
+| Live production target | Top-level Worker **`api`** via `.\scripts\set-secrets-production.ps1` (`--env=`). **Not** `--env production` (`api-production`) |
+
+Mechanical check:
+
+```powershell
+pwsh ./scripts/assert-secrets-example-parity.ps1
+```
+
+Agent rule: [`.cursor/rules/preview-production-secrets-parity.mdc`](../.cursor/rules/preview-production-secrets-parity.mdc).
+
 ## Preferred pattern
 
 1. Copy the tracked example file:
@@ -12,7 +31,10 @@ Worker secrets (Search API key, Auth0 client id, Azure Function endpoint URLs, e
    - `.\scripts\set-secrets-preview.ps1` or `scripts\set-secrets-preview.cmd`
    - `.\scripts\set-secrets-production.ps1` or `scripts\set-secrets-production.cmd`
 
-The scripts read `KEY=VALUE` lines and pipe each value to `npx wrangler secret put <KEY> --env <preview|production>`.
+The scripts read `KEY=VALUE` lines and pipe each value to `npx wrangler secret put`:
+
+- Preview → `--env preview` (`api-preview`)
+- Production → top-level Worker `api` (`--env=` / no named env). **Not** `--env production` — that targets a separate `api-production` service that does not serve `api.cultpodcasts.com`.
 
 Process environment variables with the same key names override file values if set.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts-api",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "dependencies": {
         "@cfworker/jwt": "^4.0.6",
         "@prisma/adapter-d1": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",
     "start": "wrangler dev --env local --ip 127.0.0.1 --port 8787 --local-protocol https --https-cert-path ./.cert/dev-cert.pem --https-key-path ./.cert/dev-key.pem",
     "test": "vitest run",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "assert:secrets-parity": "pwsh ./scripts/assert-secrets-example-parity.ps1"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.18.7",

--- a/scripts/assert-secrets-example-parity.ps1
+++ b/scripts/assert-secrets-example-parity.ps1
@@ -1,0 +1,84 @@
+# Fails if preview vs production Worker secret key-name sets diverge.
+# Compares tracked example files and the $secretNames lists in set-secrets-*.ps1.
+#
+# Usage (repo root):
+#   pwsh ./scripts/assert-secrets-example-parity.ps1
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$previewExample = Join-Path $PSScriptRoot 'local-secrets.preview.env.example'
+$productionExample = Join-Path $PSScriptRoot 'local-secrets.production.env.example'
+$previewScript = Join-Path $PSScriptRoot 'set-secrets-preview.ps1'
+$productionScript = Join-Path $PSScriptRoot 'set-secrets-production.ps1'
+
+function Get-DotEnvKeys([string]$Path) {
+    $keys = [System.Collections.Generic.List[string]]::new()
+    foreach ($raw in Get-Content -LiteralPath $Path) {
+        $line = $raw.Trim()
+        if ($line -eq '' -or $line.StartsWith('#')) { continue }
+        $eq = $line.IndexOf('=')
+        if ($eq -lt 1) {
+            throw "Invalid line in $Path (expected KEY=VALUE): $raw"
+        }
+        $keys.Add($line.Substring(0, $eq).Trim())
+    }
+    return ($keys | Sort-Object -Unique)
+}
+
+function Get-SecretNamesFromScript([string]$Path) {
+    $text = Get-Content -LiteralPath $Path -Raw
+    if ($text -notmatch '(?s)\$secretNames\s*=\s*@\((.*?)\)') {
+        throw "Could not find `$secretNames = @(...) in $Path"
+    }
+    $block = $Matches[1]
+    $names = [regex]::Matches($block, "'([^']+)'") | ForEach-Object { $_.Groups[1].Value }
+    if (-not $names -or $names.Count -eq 0) {
+        throw "No secret names parsed from `$secretNames in $Path"
+    }
+    return ($names | Sort-Object -Unique)
+}
+
+function Compare-KeySets([string]$LeftLabel, [string[]]$Left, [string]$RightLabel, [string[]]$Right) {
+    $onlyLeft = Compare-Object $Left $Right | Where-Object SideIndicator -eq '<=' | ForEach-Object InputObject
+    $onlyRight = Compare-Object $Left $Right | Where-Object SideIndicator -eq '=>' | ForEach-Object InputObject
+    $ok = $true
+    if ($onlyLeft) {
+        $ok = $false
+        Write-Host "FAIL: keys only in ${LeftLabel}:" -ForegroundColor Red
+        $onlyLeft | ForEach-Object { Write-Host "  $_" }
+    }
+    if ($onlyRight) {
+        $ok = $false
+        Write-Host "FAIL: keys only in ${RightLabel}:" -ForegroundColor Red
+        $onlyRight | ForEach-Object { Write-Host "  $_" }
+    }
+    return $ok
+}
+
+Push-Location $repoRoot
+try {
+    $previewKeys = Get-DotEnvKeys $previewExample
+    $productionKeys = Get-DotEnvKeys $productionExample
+    $previewScriptKeys = Get-SecretNamesFromScript $previewScript
+    $productionScriptKeys = Get-SecretNamesFromScript $productionScript
+
+    $ok = $true
+    $ok = (Compare-KeySets 'local-secrets.preview.env.example' $previewKeys 'local-secrets.production.env.example' $productionKeys) -and $ok
+    $ok = (Compare-KeySets 'set-secrets-preview.ps1 $secretNames' $previewScriptKeys 'set-secrets-production.ps1 $secretNames' $productionScriptKeys) -and $ok
+    $ok = (Compare-KeySets 'local-secrets.preview.env.example' $previewKeys 'set-secrets-preview.ps1 $secretNames' $previewScriptKeys) -and $ok
+    $ok = (Compare-KeySets 'local-secrets.production.env.example' $productionKeys 'set-secrets-production.ps1 $secretNames' $productionScriptKeys) -and $ok
+
+    if (-not $ok) {
+        Write-Host ''
+        Write-Host 'Preview/production secret key-name sets must match. See docs/worker-secrets.md and .cursor/rules/preview-production-secrets-parity.mdc.' -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "OK: preview/production secret key names match ($($previewKeys.Count) keys)."
+    exit 0
+}
+finally {
+    Pop-Location
+}

--- a/scripts/set-secrets-production.ps1
+++ b/scripts/set-secrets-production.ps1
@@ -1,4 +1,4 @@
-# Sets Cloudflare Worker secrets for the production env via wrangler.
+# Sets Cloudflare Worker secrets for the live production Worker ("api") via wrangler.
 #
 # NEVER put real secrets or Azure Function endpoint URLs in this script.
 # Load them from a gitignored local file (preferred) or process env vars.
@@ -21,7 +21,10 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-$envName = 'production'
+# Live production traffic hits the top-level Worker named "api" (`npm run deploy`
+# / `wrangler deploy` with no --env). Do NOT use --env production here: that
+# targets a separate api-production service that does not serve api.cultpodcasts.com.
+$wranglerEnvFlag = '--env='
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $secretsFile = Join-Path $PSScriptRoot 'local-secrets.production.env'
 
@@ -111,11 +114,11 @@ try {
         if ($mustBeNonEmpty -contains $name -and [string]::IsNullOrWhiteSpace($value)) {
             throw "Secret '$name' is empty. Fill it in '$secretsFile' before running."
         }
-        Write-Host "Setting $name for '$envName'..."
-        $value | npx wrangler secret put $name --env $envName
+        Write-Host "Setting $name on top-level Worker 'api'..."
+        $value | npx wrangler secret put $name $wranglerEnvFlag
     }
 
-    Write-Host "Done setting secrets for '$envName'."
+    Write-Host "Done setting secrets on top-level Worker 'api'."
 }
 finally {
     Pop-Location


### PR DESCRIPTION
## Summary
- Always-on Cursor rule + PR template requiring new Worker secret **names** in `## Config / secrets` for preview **and** production
- Fix `set-secrets-production.ps1` to target top-level Worker `api` (not `--env production` / `api-production`)
- Add `assert-secrets-example-parity.ps1` + `npm run assert:secrets-parity`
- Bump version to 1.0.21

## Config / secrets
- [x] No new Worker secrets / endpoint env keys

## Test plan
- [ ] `pwsh ./scripts/assert-secrets-example-parity.ps1` (or `npm run assert:secrets-parity`) exits 0
- [ ] Confirm PR template shows Config / secrets section on GitHub
- [ ] Spot-check `set-secrets-production.ps1` uses `--env=` for top-level `api`

Made with [Cursor](https://cursor.com)