### PR TITLE
fix(api): align episode change OpenAPI with unBluesky

### DIFF
--- a/docs/openapi-schemas-from-csharp.md
+++ b/docs/openapi-schemas-from-csharp.md
@@ -22,7 +22,7 @@ Worker-only (no Functions DTO): bookmarks Durable Object, R2 `subjects` name lis
 ## Workflow
 
 1. **Find the C# type** for the route (handler → DTO / change request).
-2. **Read `[JsonPropertyName("…")]`** — Zod keys must match JSON names, not C# property names (`BlueskyPosted` → `bluesky`, `Language` → `lang`, `Length` → `duration`).
+2. **Read `[JsonPropertyName("…")]`** — Zod keys must match JSON names, not C# property names (`UnBluesky` → `unBluesky`, `Language` → `lang`, `Length` → `duration`). Episode GET `BlueskyPosted` remains JSON `bluesky` on `EpisodeDto`.
 3. **Map types** (table below) into a new `export const …Schema = z.object({ … })` in `src/openapiSchemas.ts`. Cite the C# type in a short JSDoc (`/** Api.Dtos.EpisodeDto */`).
 4. **Wire** the schema in `src/openapiRoutes.ts` on the matching route: success status + error statuses the worker actually forwards (`proxyToAzure` options or handler returns).
 5. **Test** in `tests/openapi-schemas.spec.ts` with a minimal valid fixture (and a reject case for enums if useful).
@@ -94,7 +94,8 @@ Common mismatches to avoid:
 
 ## Example: episode change request
 
-C#: `Cloud/Api/Models/EpisodeChangeRequest.cs` → JSON `bluesky`, `lang`, `urls` (`ServiceUrls`), `images` (`ServiceImageUrls`).
+C#: `Cloud/Api/Models/EpisodeChangeRequest.cs` → JSON `unBluesky`, `lang`, `urls` (`ServiceUrls`), `images` (`ServiceImageUrls`).
+Episode GET still exposes posted state as `bluesky` on `EpisodeDto` — that is not the change-request field.
 
 Worker: `episodeChangeRequestSchema` in `src/openapiSchemas.ts`, used by update-episode routes in `openapiRoutes.ts`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts-api",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "dependencies": {
         "@cfworker/jwt": "^4.0.6",
         "@prisma/adapter-d1": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/openapiSchemas.ts
+++ b/src/openapiSchemas.ts
@@ -256,7 +256,8 @@ export const episodeChangeRequestSchema = z.object({
 	description: z.string().optional().nullable(),
 	posted: z.boolean().optional().nullable(),
 	tweeted: z.boolean().optional().nullable(),
-	bluesky: z.boolean().optional().nullable(),
+	/** When true, clear Bluesky post state and delete the remote post. Not settable via edit form. */
+	unBluesky: z.boolean().optional().nullable(),
 	ignored: z.boolean().optional().nullable(),
 	removed: z.boolean().optional().nullable(),
 	explicit: z.boolean().optional().nullable(),

--- a/tests/openapi-schemas.spec.ts
+++ b/tests/openapi-schemas.spec.ts
@@ -303,7 +303,7 @@ describe("openapi Zod schemas", () => {
 	it("accepts EpisodeChangeRequest including empty URL clears matching Angular", () => {
 		const parsed = episodeChangeRequestSchema.parse({
 			title: "New title",
-			bluesky: false,
+			unBluesky: true,
 			urls: {
 				spotify: "https://open.spotify.com/episode/x",
 				apple: "",
@@ -312,6 +312,7 @@ describe("openapi Zod schemas", () => {
 			images: { other: "" },
 			guests: ["Alice"]
 		});
+		expect(parsed.unBluesky).toBe(true);
 		expect(parsed.urls?.apple).toBe("");
 		expect(parsed.images?.other).toBe("");
 	});


### PR DESCRIPTION
## Summary
- Website edit-episode no longer sends `bluesky` on episode change; status-toggle un-post sends `unBluesky: true` (pairs with RedditPodcastPoster #954).
- Update CF Worker OpenAPI/Zod `episodeChangeRequestSchema` accordingly. Runtime proxy already forwards the raw body; this keeps Swagger/docs in sync.
- Bump to 1.0.21.

## Config / secrets
- [ ] No new Worker secrets (schema/docs only)

## Test plan
- [x] `npm test`
- [x] `npm run lint`
- [ ] After Azure #954 + website #469 deploy: status-toggle Bluesky un-post still works via CF API


Made with [Cursor](https://cursor.com)