### PR TITLE
fix(api): stop HTTP-caching curator GET /people

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts-api",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "dependencies": {
         "@cfworker/jwt": "^4.0.6",
         "@prisma/adapter-d1": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts-api",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/getPeople.ts
+++ b/src/getPeople.ts
@@ -40,7 +40,8 @@ export async function getPeople(c: Auth0ActionContext): Promise<Response> {
 
 		if (object !== null) {
 
-			AddResponseHeaders(c, { etag: object.httpEtag, methods: ["GET", "OPTIONS"] });
+			AddResponseHeaders(c, { omitCacheControlHeader: true, methods: ["GET", "OPTIONS"] });
+			c.header("Cache-Control", "no-store");
 
 			logCollector.addMessage("Successfully obtained people data.");
 
@@ -85,6 +86,7 @@ export async function getPeople(c: Auth0ActionContext): Promise<Response> {
 				console.log(logCollector.toEndpointLog());
 
 				AddResponseHeaders(c, { omitCacheControlHeader: true, methods: ["GET", "OPTIONS"] });
+				c.header("Cache-Control", "no-store");
 
 				return c.newResponse(resp.body);
 

--- a/tests/get-people.spec.ts
+++ b/tests/get-people.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("getPeople", () => {
+	it("does not HTTP-cache the curator people list", () => {
+		const src = readFileSync(resolve(process.cwd(), "src/getPeople.ts"), "utf8");
+		expect(src).toContain("omitCacheControlHeader: true");
+		expect(src).toContain('c.header("Cache-Control", "no-store")');
+		expect(src.match(/Cache-Control", "no-store"/g)?.length).toBe(2);
+		expect(src).not.toMatch(/etag:\s*object\.httpEtag/);
+	});
+});


### PR DESCRIPTION
## Summary
- Serve curator `GET /people` with `Cache-Control: no-store` so browsers do not reuse a 10-minute-stale R2 people snapshot right after create.
- Add a source-contract test for the no-store headers.

## Test plan
- [ ] `npm test` includes `tests/get-people.spec.ts` green
- [ ] After deploying Api, create a person then refresh `/people` in the episode dialog and see the new person without waiting 10 minutes

## Config / secrets
- [ ] N/A — no new Worker secrets

Made with [Cursor](https://cursor.com)